### PR TITLE
Add check when out_tensors[bounds_key] is empty

### DIFF
--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -908,9 +908,13 @@ class JointNestedRaggedTensorDict:
                     out_tensors[lengths_key] = np.concatenate(
                         (out_tensors[lengths_key], T.tensors[lengths_key])
                     )
-                    out_tensors[bounds_key] = np.concatenate(
-                        (out_tensors[bounds_key], T.tensors[bounds_key] + out_tensors[bounds_key][-1])
-                    )
+
+                    if len(out_tensors[bounds_key]) == 0:
+                        out_tensors[bounds_key] = T.tensors[bounds_key]
+                    else:
+                        out_tensors[bounds_key] = np.concatenate(
+                             (out_tensors[bounds_key], T.tensors[bounds_key] + out_tensors[bounds_key][-1])
+                         )
 
                 for key in out_keys_at_dim[dim]:
                     out_tensors[f"dim{dim}/{key}"] = (


### PR DESCRIPTION
This fixes issue [118](https://github.com/mmcdermott/EventStreamGPT/issues/118) of dev branch of [EventStreamGPT](https://github.com/mmcdermott/EventStreamGPT/tree/dev) and issue #13.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of the `concatenate` method to prevent errors related to empty tensors, enhancing the robustness of the tensor concatenation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->