### PR TITLE
Fix CI: pin pre-commit deps and emit coverage XML for Codecov

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run tests
         run: >
-          uv run pytest -v --doctest-modules --cov=src --junitxml=junit.xml -s
+          uv run pytest -v --doctest-modules --cov=src --cov-report=xml --junitxml=junit.xml -s
           --ignore=benchmark --ignore=sample_dataset_builder --ignore=docs
 
       - name: Upload coverage to Codecov
@@ -34,6 +34,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,20 +87,20 @@ repos:
 
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-gfm
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-shfmt
-          - mdformat-mkdocs
-          - mdformat-toc
-          - mdformat-admon
+          - mdformat-gfm==0.4.1
+          - mdformat-tables==1.0.0
+          - mdformat_frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-shfmt==0.2.0
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.3.0
+          - mdformat-admon==2.1.1
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
## Summary

- **Pre-commit flakiness**: `mdformat` hook on main was failing with `ImportError: cannot import name 'zip_equal' from 'more_itertools'` because the unpinned `mdformat-mkdocs` additional dependency was resolving to a version that hit a breaking change in `more_itertools>=11.0.0`. Pin every `mdformat` additional dependency to a known-compatible version and bump the hook `rev` to the last `0.7.x` release (`0.7.22`).
- **Codecov "unknown" status**: tests run with `--cov=src` but never emit `coverage.xml`, so `codecov/codecov-action@v5` logs `Found 0 coverage files to report` and reports status unknown. Add `--cov-report=xml` and point the action explicitly at `coverage.xml`.

## Test plan

- [x] `uv run pre-commit run --all-files` passes locally with the pinned dependencies.
- [x] `uv run pytest --cov=src --cov-report=xml ...` writes `coverage.xml`.
- [ ] `Code Quality Main` and `Tests` / Codecov upload green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)