### PR TITLE
Allows loading a subset of keys and an equality checker that supports equals_nan

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run benchmark
         run: |
-          uv run pytest benchmark/run.py
+          uv run pytest benchmark/run.py benchmark/run_micro.py
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -32,6 +32,18 @@ jobs:
           name: Benchmark
           tool: "customSmallerIsBetter"
           output-file-path: benchmark/outputs/output_256_512_5.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          fail-on-alert: false
+
+      - name: Store micro-benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Micro-Benchmark
+          tool: "customSmallerIsBetter"
+          output-file-path: benchmark/outputs/micro.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           alert-threshold: "150%"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run tests
         run: >
-          uv run pytest -v --doctest-modules --cov=src --junitxml=junit.xml -s
+          uv run pytest -v --doctest-modules --cov=src --cov-report=xml --junitxml=junit.xml -s
           --ignore=benchmark --ignore=sample_dataset_builder --ignore=docs
 
       - name: Upload coverage to Codecov
@@ -34,6 +34,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,20 +87,20 @@ repos:
 
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-gfm
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-shfmt
-          - mdformat-mkdocs
-          - mdformat-toc
-          - mdformat-admon
+          - mdformat-gfm==0.4.1
+          - mdformat-tables==1.0.0
+          - mdformat_frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-shfmt==0.2.0
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.3.0
+          - mdformat-admon==2.1.1
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell

--- a/benchmark/run_micro.py
+++ b/benchmark/run_micro.py
@@ -4,7 +4,11 @@ These benchmarks use synthetic data (no sample_dataset dependency) and measure i
 isolation so regressions are directly attributable.
 
 Output format is the same customSmallerIsBetter JSON consumed by github-action-benchmark, written to
-benchmark/outputs/micro.json.
+``benchmark/outputs/micro.json``. Run via the dedicated benchmark workflow (which installs the
+``benchmarks`` dependency group that provides ``rootutils``) or locally with
+``uv run pytest benchmark/run_micro.py`` after installing that group. Like ``benchmark/run.py``, this
+module is not collected by the main test suite (``tests.yaml`` uses ``--ignore=benchmark``) and is named
+without the ``test_`` prefix so bare ``pytest`` in the repo root does not auto-collect it either.
 """
 
 import json

--- a/benchmark/run_micro.py
+++ b/benchmark/run_micro.py
@@ -12,7 +12,6 @@ without the ``test_`` prefix so bare ``pytest`` in the repo root does not auto-c
 """
 
 import json
-import pickle
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -64,13 +63,6 @@ def make_2d(n_rows, row_len_range=(5, 50), seed=42):
     lo, hi = row_len_range
     rows = [list(range(int(rng.integers(lo, hi)))) for _ in range(n_rows)]
     return JointNestedRaggedTensorDict({"val": rows})
-
-
-def make_2d_raw(n_rows, row_len_range=(5, 50), seed=42):
-    """Return raw 2D list-of-lists (not wrapped in NRT)."""
-    rng = np.random.default_rng(seed)
-    lo, hi = row_len_range
-    return [list(range(int(rng.integers(lo, hi)))) for _ in range(n_rows)]
 
 
 def make_3d(n_outer, inner_range=(2, 10), leaf_range=(3, 20), seed=42):
@@ -226,60 +218,6 @@ def bench_multikey(results):
 
 
 # ---------------------------------------------------------------------------
-# Tier 2D: Naive baseline comparison
-# ---------------------------------------------------------------------------
-
-
-def _naive_padded_collate(items_2d):
-    """Naive baseline: pad a list of variable-length lists into a dense numpy array."""
-    max_len = max(len(row) for row in items_2d)
-    out = np.zeros((len(items_2d), max_len), dtype=np.int64)
-    for i, row in enumerate(items_2d):
-        out[i, : len(row)] = row
-    return out
-
-
-def bench_baseline_comparison(results):
-    """Compare NRT vs naive alternatives for collation and serialization."""
-    for label, n in SCALE_CONFIGS:
-        raw_rows = make_2d_raw(n, seed=99)
-
-        # --- Collation: naive padding vs NRT vstack+to_dense ---
-        batch_size = min(n, 64)
-        batch_raw = raw_rows[:batch_size]
-
-        def naive_collate(batch_raw=batch_raw):
-            _naive_padded_collate(batch_raw)
-
-        mean, std, count = _time(naive_collate)
-        results.append(_make_entry(f"Baseline/Collate_NaivePad/{label}", "seconds", mean, std, count))
-
-        # --- Serialization round-trip: NRT vs pickle ---
-        with TemporaryDirectory() as tmpdir:
-            nrt_fp = Path(tmpdir) / "test.nrt"
-
-            def nrt_roundtrip(raw=raw_rows, fp=nrt_fp):
-                j = JointNestedRaggedTensorDict({"val": raw})
-                j.save(fp)
-                loaded = JointNestedRaggedTensorDict(tensors_fp=fp)
-                _ = loaded.tensors
-
-            mean, std, count = _time(nrt_roundtrip)
-            results.append(_make_entry(f"Baseline/Roundtrip_NRT/{label}", "seconds", mean, std, count))
-
-            pkl_fp = Path(tmpdir) / "test.pkl"
-
-            def pkl_roundtrip(raw=raw_rows, fp=pkl_fp):
-                with open(fp, "wb") as f:
-                    pickle.dump(raw, f)
-                with open(fp, "rb") as f:
-                    pickle.load(f)
-
-            mean, std, count = _time(pkl_roundtrip)
-            results.append(_make_entry(f"Baseline/Roundtrip_Pickle/{label}", "seconds", mean, std, count))
-
-
-# ---------------------------------------------------------------------------
 # Test entry point
 # ---------------------------------------------------------------------------
 
@@ -288,7 +226,11 @@ def test_micro_benchmarks():
     """Run all micro-benchmarks and write the combined output."""
     results = []
 
-    # Tier 1A: Core operations
+    # Core NRT operations. The previous "Baseline" tier (naive numpy padded collate, pickle
+    # round-trip, and a duplicate NRT round-trip) was removed after a pickle-timing alert made
+    # it clear those entries measured pure stdlib/numpy work unaffected by any change in this
+    # repo — they produced runner-variance false alerts without providing a useful signal.
+    # Save/load regressions are still covered by bench_save_load.
     bench_getitem_int(results)
     bench_getitem_slice(results)
     bench_to_dense_1d(results)
@@ -298,9 +240,6 @@ def test_micro_benchmarks():
     bench_concatenate(results)
     bench_save_load(results)
     bench_multikey(results)
-
-    # Tier 2D: Baseline comparison
-    bench_baseline_comparison(results)
 
     output_fp = OUTPUT_DIR / "micro.json"
     output_fp.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmark/test_micro.py
+++ b/benchmark/test_micro.py
@@ -1,0 +1,303 @@
+"""Micro-benchmarks for core NRT operations.
+
+These benchmarks use synthetic data (no sample_dataset dependency) and measure individual operations in
+isolation so regressions are directly attributable.
+
+Output format is the same customSmallerIsBetter JSON consumed by github-action-benchmark, written to
+benchmark/outputs/micro.json.
+"""
+
+import json
+import pickle
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import rootutils
+
+from nested_ragged_tensors.ragged_numpy import JointNestedRaggedTensorDict
+
+root = rootutils.setup_root(__file__, dotenv=True, pythonpath=True, cwd=False)
+OUTPUT_DIR = root / "benchmark" / "outputs"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Repeat count for timing stability
+N_REPEATS = 5
+
+
+def _time(fn, n_repeats=N_REPEATS):
+    """Run *fn* several times and return (mean_seconds, std_seconds, count)."""
+    times = []
+    for _ in range(n_repeats):
+        start = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - start)
+    arr = np.array(times)
+    return float(arr.mean()), float(arr.std(ddof=1)), len(times)
+
+
+def _make_entry(name, unit, mean, std, count):
+    return {"name": name, "unit": unit, "value": mean, "range": std, "extra": f"Count: {count}"}
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data generators
+# ---------------------------------------------------------------------------
+
+
+def make_1d(n_elements):
+    """Flat 1D tensor: ``{"val": [1, 2, ..., n]}``."""
+    return JointNestedRaggedTensorDict({"val": list(range(n_elements))})
+
+
+def make_2d(n_rows, row_len_range=(5, 50), seed=42):
+    """2D ragged: each row has a random number of elements."""
+    rng = np.random.default_rng(seed)
+    lo, hi = row_len_range
+    rows = [list(range(int(rng.integers(lo, hi)))) for _ in range(n_rows)]
+    return JointNestedRaggedTensorDict({"val": rows})
+
+
+def make_2d_raw(n_rows, row_len_range=(5, 50), seed=42):
+    """Return raw 2D list-of-lists (not wrapped in NRT)."""
+    rng = np.random.default_rng(seed)
+    lo, hi = row_len_range
+    return [list(range(int(rng.integers(lo, hi)))) for _ in range(n_rows)]
+
+
+def make_3d(n_outer, inner_range=(2, 10), leaf_range=(3, 20), seed=42):
+    """3D ragged: outer → inner lists → leaf lists."""
+    rng = np.random.default_rng(seed)
+    data = []
+    for _ in range(n_outer):
+        n_inner = int(rng.integers(*inner_range))
+        inner = [list(range(int(rng.integers(*leaf_range)))) for _ in range(n_inner)]
+        data.append(inner)
+    return JointNestedRaggedTensorDict({"val": data})
+
+
+def make_multikey_2d(n_rows, n_keys=4, row_len_range=(5, 50), seed=42):
+    """2D ragged with multiple keys sharing the same bounds."""
+    rng = np.random.default_rng(seed)
+    lo, hi = row_len_range
+    lengths = [int(rng.integers(lo, hi)) for _ in range(n_rows)]
+    raw = {}
+    for k in range(n_keys):
+        raw[f"key_{k}"] = [list(range(length)) for length in lengths]
+    return JointNestedRaggedTensorDict(raw)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark definitions
+# ---------------------------------------------------------------------------
+
+SCALE_CONFIGS = [
+    ("small", 100),
+    ("medium", 1_000),
+    ("large", 10_000),
+]
+
+
+def bench_getitem_int(results):
+    """Benchmark single-element integer indexing."""
+    for label, n in SCALE_CONFIGS:
+        J = make_2d(n)
+        indices = list(range(min(n, 200)))  # index up to 200 elements
+
+        def run(J=J, indices=indices):
+            for i in indices:
+                J[i]
+
+        mean, std, count = _time(run)
+        # Normalize to per-element time
+        per_item = mean / len(indices)
+        per_item_std = std / len(indices)
+        results.append(_make_entry(f"CoreOps/GetItem_Int/{label}", "seconds", per_item, per_item_std, count))
+
+
+def bench_getitem_slice(results):
+    """Benchmark slice indexing."""
+    for label, n in SCALE_CONFIGS:
+        J = make_2d(n)
+        slice_size = max(1, n // 10)
+
+        def run(J=J, s=slice_size):
+            J[0:s]
+
+        mean, std, count = _time(run)
+        results.append(_make_entry(f"CoreOps/GetItem_Slice/{label}", "seconds", mean, std, count))
+
+
+def bench_to_dense_1d(results):
+    """Benchmark to_dense on flat 1D tensors."""
+    for label, n in SCALE_CONFIGS:
+        J = make_1d(n)
+        mean, std, count = _time(lambda J=J: J.to_dense())
+        results.append(_make_entry(f"CoreOps/ToDense_1D/{label}", "seconds", mean, std, count))
+
+
+def bench_to_dense_2d(results):
+    """Benchmark to_dense on 2D ragged tensors."""
+    for label, n in SCALE_CONFIGS:
+        J = make_2d(n)
+        mean, std, count = _time(lambda J=J: J.to_dense())
+        results.append(_make_entry(f"CoreOps/ToDense_2D/{label}", "seconds", mean, std, count))
+
+
+def bench_to_dense_3d(results):
+    """Benchmark to_dense on 3D ragged tensors."""
+    for label, n in SCALE_CONFIGS:
+        J = make_3d(n)
+        mean, std, count = _time(lambda J=J: J.to_dense())
+        results.append(_make_entry(f"CoreOps/ToDense_3D/{label}", "seconds", mean, std, count))
+
+
+COLLATE_BATCH_SIZES = [
+    ("batch16", 16),
+    ("batch64", 64),
+    ("batch256", 256),
+]
+
+
+def bench_vstack_to_dense(results):
+    """Benchmark the collation path: vstack individual items then to_dense."""
+    J = make_2d(1000)
+    for label, batch_size in COLLATE_BATCH_SIZES:
+        items = [J[i % len(J)] for i in range(batch_size)]
+
+        def run(items=items):
+            stacked = JointNestedRaggedTensorDict.vstack(items)
+            stacked.to_dense()
+
+        mean, std, count = _time(run)
+        results.append(_make_entry(f"CoreOps/Collate_VStack_ToDense/{label}", "seconds", mean, std, count))
+
+
+def bench_concatenate(results):
+    """Benchmark concatenation of multiple tensors."""
+    for label, n in SCALE_CONFIGS:
+        chunks = [make_2d(max(1, n // 4), row_len_range=(5, 20), seed=100 + i) for i in range(4)]
+
+        def run(chunks=chunks):
+            JointNestedRaggedTensorDict.concatenate(chunks)
+
+        mean, std, count = _time(run)
+        results.append(_make_entry(f"CoreOps/Concatenate/{label}", "seconds", mean, std, count))
+
+
+def bench_save_load(results):
+    """Benchmark save to disk and load from disk."""
+    for label, n in SCALE_CONFIGS:
+        J = make_2d(n)
+
+        with TemporaryDirectory() as tmpdir:
+            fp = Path(tmpdir) / "test.nrt"
+
+            # Save benchmark
+            mean, std, count = _time(lambda J=J, fp=fp: J.save(fp))
+            results.append(_make_entry(f"CoreOps/Save/{label}", "seconds", mean, std, count))
+
+            # Ensure file exists for load benchmark
+            J.save(fp)
+
+            # Load benchmark
+            def load(fp=fp):
+                loaded = JointNestedRaggedTensorDict(tensors_fp=fp)
+                _ = loaded.tensors  # force lazy load
+
+            mean, std, count = _time(load)
+            results.append(_make_entry(f"CoreOps/Load/{label}", "seconds", mean, std, count))
+
+
+def bench_multikey(results):
+    """Benchmark to_dense with multiple keys sharing bounds."""
+    for label, n in SCALE_CONFIGS:
+        J = make_multikey_2d(n, n_keys=4)
+        mean, std, count = _time(lambda J=J: J.to_dense())
+        results.append(_make_entry(f"CoreOps/ToDense_MultiKey/{label}", "seconds", mean, std, count))
+
+
+# ---------------------------------------------------------------------------
+# Tier 2D: Naive baseline comparison
+# ---------------------------------------------------------------------------
+
+
+def _naive_padded_collate(items_2d):
+    """Naive baseline: pad a list of variable-length lists into a dense numpy array."""
+    max_len = max(len(row) for row in items_2d)
+    out = np.zeros((len(items_2d), max_len), dtype=np.int64)
+    for i, row in enumerate(items_2d):
+        out[i, : len(row)] = row
+    return out
+
+
+def bench_baseline_comparison(results):
+    """Compare NRT vs naive alternatives for collation and serialization."""
+    for label, n in SCALE_CONFIGS:
+        raw_rows = make_2d_raw(n, seed=99)
+
+        # --- Collation: naive padding vs NRT vstack+to_dense ---
+        batch_size = min(n, 64)
+        batch_raw = raw_rows[:batch_size]
+
+        def naive_collate(batch_raw=batch_raw):
+            _naive_padded_collate(batch_raw)
+
+        mean, std, count = _time(naive_collate)
+        results.append(_make_entry(f"Baseline/Collate_NaivePad/{label}", "seconds", mean, std, count))
+
+        # --- Serialization round-trip: NRT vs pickle ---
+        with TemporaryDirectory() as tmpdir:
+            nrt_fp = Path(tmpdir) / "test.nrt"
+
+            def nrt_roundtrip(raw=raw_rows, fp=nrt_fp):
+                j = JointNestedRaggedTensorDict({"val": raw})
+                j.save(fp)
+                loaded = JointNestedRaggedTensorDict(tensors_fp=fp)
+                _ = loaded.tensors
+
+            mean, std, count = _time(nrt_roundtrip)
+            results.append(_make_entry(f"Baseline/Roundtrip_NRT/{label}", "seconds", mean, std, count))
+
+            pkl_fp = Path(tmpdir) / "test.pkl"
+
+            def pkl_roundtrip(raw=raw_rows, fp=pkl_fp):
+                with open(fp, "wb") as f:
+                    pickle.dump(raw, f)
+                with open(fp, "rb") as f:
+                    pickle.load(f)
+
+            mean, std, count = _time(pkl_roundtrip)
+            results.append(_make_entry(f"Baseline/Roundtrip_Pickle/{label}", "seconds", mean, std, count))
+
+
+# ---------------------------------------------------------------------------
+# Test entry point
+# ---------------------------------------------------------------------------
+
+
+def test_micro_benchmarks():
+    """Run all micro-benchmarks and write the combined output."""
+    results = []
+
+    # Tier 1A: Core operations
+    bench_getitem_int(results)
+    bench_getitem_slice(results)
+    bench_to_dense_1d(results)
+    bench_to_dense_2d(results)
+    bench_to_dense_3d(results)
+    bench_vstack_to_dense(results)
+    bench_concatenate(results)
+    bench_save_load(results)
+    bench_multikey(results)
+
+    # Tier 2D: Baseline comparison
+    bench_baseline_comparison(results)
+
+    output_fp = OUTPUT_DIR / "micro.json"
+    output_fp.parent.mkdir(parents=True, exist_ok=True)
+    output_fp.write_text(json.dumps(results, indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["safetensors", "numpy"]
+dependencies = ["safetensors", "numpy>=1.21"]
 
 [dependency-groups]
 dev = ["pre-commit<4", "ruff", "pytest", "pytest-cov"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["safetensors", "numpy>=1.21"]
+dependencies = ["safetensors>=0.3.1", "numpy>=1.21"]
 
 [dependency-groups]
 dev = ["pre-commit<4", "ruff", "pytest", "pytest-cov"]

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -167,12 +167,15 @@ class JointNestedRaggedTensorDict:
             processed_tensors: The tensors to be stored, in pre-processed format.
             tensors_fp: The filepath from which to load the pre-processed tensors in safetensors format.
             schema: The schema for the tensors, if known.
-            keys: Restricts the subset of user-level keys loaded from ``tensors_fp``. Only valid when
-                ``tensors_fp`` is provided. When supplied, the backing safetensors archive is opened
-                lazily and only the ``dim*/{k}`` entries for the requested keys are read into memory
-                (the ``dim*/bounds`` entries required for dense reconstruction are always kept).
-                Operations that only reference the loaded keys work unchanged; operations that
-                touch a non-loaded key raise a ``KeyError``.
+            keys: Restricts the subset of user-level keys visible from ``tensors_fp``. Only valid
+                when ``tensors_fp`` is provided. When supplied, the backing safetensors archive
+                is opened at init only long enough to validate the requested keys and determine
+                which ``dim*/bounds`` entries are required; no tensor values are read until an
+                operation actually needs them. Subsequent reads happen lazily through
+                ``safe_open`` and only touch the ``dim*/{k}`` entries for the requested keys (or
+                the required ``dim*/bounds``). Operations that reference a non-selected key
+                raise ``KeyError``. ``keys`` must be a non-empty iterable of strings; passing a
+                bare ``str``/``bytes`` raises ``TypeError``.
 
         Examples:
             >>> import tempfile
@@ -276,6 +279,43 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             ValueError: `keys` may only be specified alongside `tensors_fp`.
+
+            ``keys`` must be a non-empty iterable of strings. Bare strings are rejected (so a
+            typo like ``keys="T"`` doesn't silently iterate character-by-character), non-str
+            elements are rejected, empty collections are rejected, and the reserved meta-names
+            ``bounds`` / ``mask`` are rejected (they refer to internal ragged-structure tensors,
+            not user-level data).
+
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys="A")
+            Traceback (most recent call last):
+                ...
+            TypeError: `keys` must be an iterable of strings, not a bare str/bytes.
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys=[])
+            Traceback (most recent call last):
+                ...
+            ValueError: `keys` must be non-empty.
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys={"A", 1})
+            Traceback (most recent call last):
+                ...
+            TypeError: `keys` must contain only strings; got elements of type ['int'].
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [[1, 2], [3]]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys={"bounds"})
+            ... # doctest: +NORMALIZE_WHITESPACE
+            Traceback (most recent call last):
+                ...
+            ValueError: `keys` may not contain reserved meta-names ['bounds'];
+                these refer to internal ragged-structure tensors, not user-level data.
         """
         args = [
             ("raw_tensors", raw_tensors),
@@ -292,6 +332,7 @@ class JointNestedRaggedTensorDict:
         if keys is not None and tensors_fp is None:
             raise ValueError("`keys` may only be specified alongside `tensors_fp`.")
 
+        self._subset_keys: list[str] | None = None
         self._schema = schema if schema is not None else {}
         if raw_tensors is not None:
             self._initialize_tensors(raw_tensors)
@@ -301,45 +342,74 @@ class JointNestedRaggedTensorDict:
             if not tensors_fp.is_file():
                 raise FileNotFoundError(f"Tensors filepath must exist, got {tensors_fp}")
             self._tensors_fp = tensors_fp
-            if keys is None:
-                self._tensors = None
-            else:
-                self._tensors = self._load_subset(tensors_fp, keys)
+            self._tensors = None
+            if keys is not None:
+                self._subset_keys = self._resolve_subset_keys(tensors_fp, keys)
+
+    _RESERVED_SUBSET_NAMES: tuple[str, ...] = ("bounds", "mask")
 
     @staticmethod
-    def _load_subset(tensors_fp: Path, keys: Iterable[str]) -> dict[str, np.ndarray]:
-        """Eagerly reads a user-requested subset of user-level keys from a safetensors archive.
+    def _resolve_subset_keys(tensors_fp: Path, keys: Iterable[str]) -> list[str]:
+        """Resolves the list of safetensors keys to expose for a subset load.
 
-        For each requested user-level key ``k``, the matching ``dim*/k`` entry is read. The
-        ``dim*/bounds`` entries up to the deepest requested key's dimension are also loaded
-        because they are required for slicing and dense reconstruction. Bounds for deeper dims
-        are skipped — they are never referenced by operations that only touch the loaded keys.
-        Missing keys raise a ``KeyError`` that lists what is actually available in the file.
+        Opens ``tensors_fp`` for metadata only (no tensor reads). Validates that every requested
+        user-level key ``k`` maps to at least one ``dim*/k`` entry and returns the full list of
+        ``dim*/k`` entries to expose, plus the ``dim*/bounds`` entries up to the deepest
+        requested dimension (needed for slicing and dense reconstruction). Deeper bounds are
+        skipped — they are never referenced by operations that only touch the selected keys.
+        The returned list preserves the archive's raw storage order as reported by
+        ``safe_open(...).keys()``, so subset materialization is deterministic relative to the
+        safetensors key order. Note that this order may differ from ``load_file(...)`` output,
+        which re-groups meta keys; matching ``load_file`` exactly would require reading every
+        tensor, which would defeat the lazy subset load.
+
+        ``keys`` must be a non-empty iterable of strings. Bare ``str``/``bytes`` raise
+        ``TypeError`` (so ``keys="T"`` doesn't silently iterate character-by-character). Non-str
+        elements also raise ``TypeError``. Reserved meta-names (``bounds``, ``mask``) are
+        rejected with ``ValueError``. An empty iterable raises ``ValueError``. Missing keys
+        raise ``KeyError`` listing what is actually available.
         """
+        if isinstance(keys, (str, bytes)):
+            raise TypeError("`keys` must be an iterable of strings, not a bare str/bytes.")
         requested = set(keys)
-        with safe_open(tensors_fp, framework="np") as f:
-            stored = set(f.keys())
-            needed = set()
-            missing = set()
-            max_requested_dim = -1
-            for req in requested:
-                matches = {k for k in stored if k.split("/", 1)[1] == req}
-                if not matches:
-                    missing.add(req)
-                    continue
-                needed.update(matches)
-                max_requested_dim = max(max_requested_dim, *(int(k.split("/", 1)[0][3:]) for k in matches))
-            if missing:
-                available = sorted({k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] != "bounds"})
-                raise KeyError(
-                    f"Requested keys {sorted(missing)} not found in {tensors_fp}. Available: {available}"
-                )
-            needed.update(
-                k
-                for k in stored
-                if k.split("/", 1)[1] == "bounds" and int(k.split("/", 1)[0][3:]) <= max_requested_dim
+        if not requested:
+            raise ValueError("`keys` must be non-empty.")
+        bad_types = sorted({type(k).__name__ for k in requested if not isinstance(k, str)})
+        if bad_types:
+            raise TypeError(f"`keys` must contain only strings; got elements of type {bad_types}.")
+        reserved = requested & set(JointNestedRaggedTensorDict._RESERVED_SUBSET_NAMES)
+        if reserved:
+            raise ValueError(
+                f"`keys` may not contain reserved meta-names {sorted(reserved)}; these refer "
+                "to internal ragged-structure tensors, not user-level data."
             )
-            return {k: f.get_tensor(k) for k in needed}
+        with safe_open(tensors_fp, framework="np") as f:
+            stored_order = list(f.keys())
+        stored = set(stored_order)
+        needed: set[str] = set()
+        missing: set[str] = set()
+        max_requested_dim = -1
+        for req in requested:
+            matches = {k for k in stored if k.split("/", 1)[1] == req}
+            if not matches:
+                missing.add(req)
+                continue
+            needed.update(matches)
+            max_requested_dim = max(max_requested_dim, *(int(k.split("/", 1)[0][3:]) for k in matches))
+        if missing:
+            reserved_names = set(JointNestedRaggedTensorDict._RESERVED_SUBSET_NAMES)
+            available = sorted(
+                {k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] not in reserved_names}
+            )
+            raise KeyError(
+                f"Requested keys {sorted(missing)} not found in {tensors_fp}. Available: {available}"
+            )
+        needed.update(
+            k
+            for k in stored
+            if k.split("/", 1)[1] == "bounds" and int(k.split("/", 1)[0][3:]) <= max_requested_dim
+        )
+        return [k for k in stored_order if k in needed]
 
     def __eq__(self, other: object) -> bool:
         """Checks if this JointNestedRaggedTensorDict is equal to another object.
@@ -440,17 +510,42 @@ class JointNestedRaggedTensorDict:
 
     @property
     def tensors(self) -> dict[str, np.ndarray]:
+        """Materialized dict of all stored tensors, keyed as ``dim*/name``.
+
+        Loads from disk on first access when backed by ``tensors_fp``. When the instance was
+        constructed with ``keys=``, only the resolved subset is loaded — the unselected entries
+        are never read. Iteration order of the returned dict is the archive's raw storage order
+        (as reported by ``safe_open().keys()``) filtered to the subset, so it is deterministic
+        across runs rather than depending on set-hash iteration.
+
+        Examples:
+            >>> import tempfile
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({
+            ...         "T":  [[1, 2, 3], [4, 5]],
+            ...         "id": [[[1, 2, 3], [3, 4], [1, 2]], [[3], [3, 2, 2]]],
+            ...     }).save(fp)
+            ...     sub = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"}).tensors
+            ...     list(sub)
+            ['dim1/T', 'dim1/bounds']
+        """
         if self._tensors is None:
-            self._tensors = load_file(self._tensors_fp)
+            if self._subset_keys is not None:
+                with safe_open(self._tensors_fp, framework="np") as f:
+                    self._tensors = {k: f.get_tensor(k) for k in self._subset_keys}
+            else:
+                self._tensors = load_file(self._tensors_fp)
         return self._tensors
 
     @cached_property
     def _tensor_keys(self) -> set[str]:
-        if self._tensors is None:
-            with safe_open(self._tensors_fp, framework="np") as f:
-                return set(f.keys())
-        else:
+        if self._tensors is not None:
             return set(self._tensors.keys())
+        if self._subset_keys is not None:
+            return set(self._subset_keys)
+        with safe_open(self._tensors_fp, framework="np") as f:
+            return set(f.keys())
 
     @contextmanager
     def _tensor_at_key(self, key: str):

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -344,6 +344,11 @@ class JointNestedRaggedTensorDict:
     def __eq__(self, other: object) -> bool:
         """Checks if this JointNestedRaggedTensorDict is equal to another object.
 
+        Follows IEEE semantics for floating-point values: ``NaN != NaN``, so two NRTs containing
+        ``NaN`` values will compare unequal even if they are bitwise-identical. Callers who want
+        to treat ``NaN`` as equal to itself (e.g. when checking save/load roundtrips of tensors
+        that use ``NaN`` as a sentinel) should use :meth:`equals` with ``equal_nan=True``.
+
         Examples:
             >>> data = {"A": [[1, 2, 3], [4, 5]], "B": [1, 2]}
             >>> J = JointNestedRaggedTensorDict(data)
@@ -364,8 +369,39 @@ class JointNestedRaggedTensorDict:
             ...    J2 = JointNestedRaggedTensorDict(tensors_fp=fp)
             ...    J == J2
             True
-        """
 
+            ``NaN`` values follow IEEE semantics and are never equal to themselves, so NRTs
+            containing ``NaN`` compare unequal under ``==`` even when bitwise-identical. Use
+            :meth:`equals` with ``equal_nan=True`` when that behavior is undesired.
+
+            >>> nan_data = {"T": [[float("nan"), 1.0], [float("nan"), 2.0]]}
+            >>> JointNestedRaggedTensorDict(nan_data) == JointNestedRaggedTensorDict(nan_data)
+            False
+        """
+        return self.equals(other, equal_nan=False)
+
+    def equals(self, other: object, equal_nan: bool = False) -> bool:
+        """Checks equality with configurable ``NaN`` handling.
+
+        Identical in logic to :meth:`__eq__`, except that ``equal_nan`` controls whether two
+        ``NaN`` values at the same position are treated as equal (``True``) or unequal
+        (``False``, matching IEEE 754). ``__eq__`` calls this with ``equal_nan=False``.
+
+        Args:
+            other: The object to compare against.
+            equal_nan: If ``True``, two ``NaN`` values at the same position compare equal. If
+                ``False``, ``NaN != NaN`` as in standard IEEE semantics.
+
+        Examples:
+            >>> nan_data = {"T": [[float("nan"), 1.0], [float("nan"), 2.0]]}
+            >>> J = JointNestedRaggedTensorDict(nan_data)
+            >>> J.equals(JointNestedRaggedTensorDict(nan_data))
+            False
+            >>> J.equals(JointNestedRaggedTensorDict(nan_data), equal_nan=True)
+            True
+            >>> J.equals({"T": [[float("nan"), 1.0], [float("nan"), 2.0]]}, equal_nan=True)
+            False
+        """
         if not isinstance(other, JointNestedRaggedTensorDict):
             return False
 
@@ -373,7 +409,7 @@ class JointNestedRaggedTensorDict:
             return False
 
         for k in self._tensor_keys:
-            if not np.array_equal(self.tensors[k], other.tensors[k]):
+            if not np.array_equal(self.tensors[k], other.tensors[k], equal_nan=equal_nan):
                 return False
 
         return True

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
@@ -158,6 +158,7 @@ class JointNestedRaggedTensorDict:
         processed_tensors: dict[str, np.ndarray] | None = None,
         tensors_fp: Path | None = None,
         schema: dict[str, np.dtype] | None = None,
+        keys: Iterable[str] | None = None,
     ):
         """Initializes JointNestedRaggedTensorDict with the given tensors.
 
@@ -166,6 +167,12 @@ class JointNestedRaggedTensorDict:
             processed_tensors: The tensors to be stored, in pre-processed format.
             tensors_fp: The filepath from which to load the pre-processed tensors in safetensors format.
             schema: The schema for the tensors, if known.
+            keys: Restricts the subset of user-level keys loaded from ``tensors_fp``. Only valid when
+                ``tensors_fp`` is provided. When supplied, the backing safetensors archive is opened
+                lazily and only the ``dim*/{k}`` entries for the requested keys are read into memory
+                (the ``dim*/bounds`` entries required for dense reconstruction are always kept).
+                Operations that only reference the loaded keys work unchanged; operations that
+                touch a non-loaded key raise a ``KeyError``.
 
         Examples:
             >>> import tempfile
@@ -220,6 +227,55 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             ValueError: Failed to parse D as a nested list of numbers!
+
+            ``keys=`` restricts which user-level keys are loaded from ``tensors_fp``. The
+            resulting object behaves like a normal ``JointNestedRaggedTensorDict`` for
+            operations that only reference the requested keys, but the unselected tensors
+            are never read from disk.
+
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({
+            ...         "T":   [[1,           2,        3       ], [4,   5          ]],
+            ...         "id":  [[[1, 2,   3], [3,   4], [1, 2  ]], [[3], [3,   2, 2]]],
+            ...         "val": [[[1, 0.2, 0], [3.1, 0], [1, 2.2]], [[3], [3.3, 2, 0]]],
+            ...     }).save(fp)
+            ...     subset = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T", "id"})
+            ...     assert subset.keys() == {"T", "id"}
+            ...     subset[1].to_dense()["T"]
+            array([4, 5], dtype=uint8)
+
+            Only the ``dim*/bounds`` entries up to the deepest requested key are loaded; deeper
+            bounds are skipped, so ``max_n_dims`` reflects the loaded subset rather than the
+            on-disk shape.
+
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({
+            ...         "T":   [[1,           2,        3       ], [4,   5          ]],
+            ...         "id":  [[[1, 2,   3], [3,   4], [1, 2  ]], [[3], [3,   2, 2]]],
+            ...     }).save(fp)
+            ...     shallow = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"})
+            ...     shallow.max_n_dims
+            2
+
+            Requesting a key that does not exist in the file raises a clear error.
+
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys={"A", "missing"})
+            ... # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            KeyError: "Requested keys ['missing'] not found in ...tensors.nrt. Available: ['A']"
+
+            ``keys=`` is only valid alongside ``tensors_fp``.
+
+            >>> JointNestedRaggedTensorDict(raw_tensors={"A": [1, 2, 3]}, keys={"A"})
+            Traceback (most recent call last):
+                ...
+            ValueError: `keys` may only be specified alongside `tensors_fp`.
         """
         args = [
             ("raw_tensors", raw_tensors),
@@ -233,6 +289,9 @@ class JointNestedRaggedTensorDict:
                 f"{args_str}"
             )
 
+        if keys is not None and tensors_fp is None:
+            raise ValueError("`keys` may only be specified alongside `tensors_fp`.")
+
         self._schema = schema if schema is not None else {}
         if raw_tensors is not None:
             self._initialize_tensors(raw_tensors)
@@ -241,8 +300,46 @@ class JointNestedRaggedTensorDict:
         elif tensors_fp is not None:
             if not tensors_fp.is_file():
                 raise FileNotFoundError(f"Tensors filepath must exist, got {tensors_fp}")
-            self._tensors = None
             self._tensors_fp = tensors_fp
+            if keys is None:
+                self._tensors = None
+            else:
+                self._tensors = self._load_subset(tensors_fp, keys)
+
+    @staticmethod
+    def _load_subset(tensors_fp: Path, keys: Iterable[str]) -> dict[str, np.ndarray]:
+        """Eagerly reads a user-requested subset of user-level keys from a safetensors archive.
+
+        For each requested user-level key ``k``, the matching ``dim*/k`` entry is read. The
+        ``dim*/bounds`` entries up to the deepest requested key's dimension are also loaded
+        because they are required for slicing and dense reconstruction. Bounds for deeper dims
+        are skipped — they are never referenced by operations that only touch the loaded keys.
+        Missing keys raise a ``KeyError`` that lists what is actually available in the file.
+        """
+        requested = set(keys)
+        with safe_open(tensors_fp, framework="np") as f:
+            stored = set(f.keys())
+            needed = set()
+            missing = set()
+            max_requested_dim = -1
+            for req in requested:
+                matches = {k for k in stored if k.split("/", 1)[1] == req}
+                if not matches:
+                    missing.add(req)
+                    continue
+                needed.update(matches)
+                max_requested_dim = max(max_requested_dim, *(int(k.split("/", 1)[0][3:]) for k in matches))
+            if missing:
+                available = sorted({k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] != "bounds"})
+                raise KeyError(
+                    f"Requested keys {sorted(missing)} not found in {tensors_fp}. Available: {available}"
+                )
+            needed.update(
+                k
+                for k in stored
+                if k.split("/", 1)[1] == "bounds" and int(k.split("/", 1)[0][3:]) <= max_requested_dim
+            )
+            return {k: f.get_tensor(k) for k in needed}
 
     def __eq__(self, other: object) -> bool:
         """Checks if this JointNestedRaggedTensorDict is equal to another object.

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -234,7 +234,8 @@ class JointNestedRaggedTensorDict:
             ``keys=`` restricts which user-level keys are loaded from ``tensors_fp``. The
             resulting object behaves like a normal ``JointNestedRaggedTensorDict`` for
             operations that only reference the requested keys, but the unselected tensors
-            are never read from disk.
+            are never read from disk. Without ``keys=``, every user-level key stored in the
+            file is exposed:
 
             >>> with tempfile.TemporaryDirectory() as dirpath:
             ...     fp = Path(dirpath) / "tensors.nrt"
@@ -243,14 +244,18 @@ class JointNestedRaggedTensorDict:
             ...         "id":  [[[1, 2,   3], [3,   4], [1, 2  ]], [[3], [3,   2, 2]]],
             ...         "val": [[[1, 0.2, 0], [3.1, 0], [1, 2.2]], [[3], [3.3, 2, 0]]],
             ...     }).save(fp)
+            ...     full = JointNestedRaggedTensorDict(tensors_fp=fp)
             ...     subset = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T", "id"})
+            ...     assert full.keys() == {"T", "id", "val"}
             ...     assert subset.keys() == {"T", "id"}
             ...     subset[1].to_dense()["T"]
             array([4, 5], dtype=uint8)
 
             Only the ``dim*/bounds`` entries up to the deepest requested key are loaded; deeper
             bounds are skipped, so ``max_n_dims`` reflects the loaded subset rather than the
-            on-disk shape.
+            on-disk shape. Attempting to read a non-selected key via the internal lazy-read path
+            raises ``KeyError`` so that the subset contract is enforced rather than silently
+            bypassed.
 
             >>> with tempfile.TemporaryDirectory() as dirpath:
             ...     fp = Path(dirpath) / "tensors.nrt"
@@ -261,6 +266,19 @@ class JointNestedRaggedTensorDict:
             ...     shallow = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"})
             ...     shallow.max_n_dims
             2
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({
+            ...         "T":  [[1, 2, 3], [4, 5]],
+            ...         "id": [[[1, 2, 3], [3, 4], [1, 2]], [[3], [3, 2, 2]]],
+            ...     }).save(fp)
+            ...     shallow = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"})
+            ...     with shallow._tensor_at_key("dim2/id"):
+            ...         pass
+            ... # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            KeyError: "Key 'dim2/id' is not part of the loaded subset [...]."
 
             Requesting a key that does not exist in the file raises a clear error.
 
@@ -371,12 +389,13 @@ class JointNestedRaggedTensorDict:
         """
         if isinstance(keys, (str, bytes)):
             raise TypeError("`keys` must be an iterable of strings, not a bare str/bytes.")
-        requested = set(keys)
-        if not requested:
+        requested_list = list(keys)
+        if not requested_list:
             raise ValueError("`keys` must be non-empty.")
-        bad_types = sorted({type(k).__name__ for k in requested if not isinstance(k, str)})
+        bad_types = sorted({type(k).__name__ for k in requested_list if not isinstance(k, str)})
         if bad_types:
             raise TypeError(f"`keys` must contain only strings; got elements of type {bad_types}.")
+        requested = set(requested_list)
         reserved = requested & set(JointNestedRaggedTensorDict._RESERVED_SUBSET_NAMES)
         if reserved:
             raise ValueError(
@@ -549,6 +568,8 @@ class JointNestedRaggedTensorDict:
 
     @contextmanager
     def _tensor_at_key(self, key: str):
+        if self._subset_keys is not None and key not in self._subset_keys:
+            raise KeyError(f"Key {key!r} is not part of the loaded subset {sorted(self._subset_keys)}.")
         if self._tensors is None:
             with safe_open(self._tensors_fp, framework="np") as f:
                 yield f.get_slice(key)

--- a/uv.lock
+++ b/uv.lock
@@ -942,8 +942,8 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.31" },
     { name = "mkdocs-section-index", marker = "extra == 'docs'", specifier = ">=0.3.9" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.26" },
-    { name = "numpy" },
-    { name = "safetensors" },
+    { name = "numpy", specifier = ">=1.21" },
+    { name = "safetensors", specifier = ">=0.3.1" },
 ]
 provides-extras = ["docs"]
 


### PR DESCRIPTION
Release rollup: subset-keys loading, `equal_nan` equality, micro-benchmarks, and infrastructure pins.

## New features

### Load a subset of user-level keys lazily (`keys=`) — closes #60

`JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T", "id"})` now restricts the loaded NRT to the requested user-level keys. The load is genuinely lazy: at `__init__` the archive is opened only for metadata (`safe_open().keys()`) to validate the requested keys and determine which `dim*/bounds` entries are needed. No tensor values are read until an operation actually asks for one. The `.tensors` property, when forced, also materializes only the selected subset rather than `load_file`-ing the whole archive. Order of the materialized dict matches `safe_open().keys()` (deterministic across runs).

Validation:
- `keys=` is only valid alongside `tensors_fp=`.
- Bare `str`/`bytes` raise `TypeError` so `keys="T"` doesn't silently iterate character-by-character.
- Non-string elements raise `TypeError` with the offending types listed.
- Empty iterables raise `ValueError`.
- Reserved meta-names (`bounds`, `mask`) raise `ValueError` — they refer to internal ragged-structure tensors, not user-level data.
- Missing keys raise `KeyError` with the available user-level keys listed (filtered against `_RESERVED_SUBSET_NAMES`).
- `_tensor_at_key` enforces the subset contract: reading a non-selected key raises `KeyError` rather than silently falling through to disk.

### `NaN`-aware equality via `.equals(..., equal_nan=...)` — closes #63

`JointNestedRaggedTensorDict.__eq__` stays IEEE-faithful (`NaN != NaN` under `==`). A new `.equals(other, equal_nan: bool = False)` method exposes configurable `NaN` handling — callers who want "`NaN` round-trips equal to itself" (e.g. when verifying save/load roundtrips of tensors that use `NaN` as a sentinel) write `a.equals(b, equal_nan=True)`. `__eq__` delegates to `.equals(..., equal_nan=False)` so there is a single source of truth for the comparison logic.

### Micro-benchmarks for core NRT ops

`benchmark/run_micro.py` adds synthetic-data micro-benchmarks for `__getitem__` (int / slice), `to_dense` (1D / 2D / 3D / multikey), `vstack + to_dense`, `concatenate`, and `save` / `load`, each across small / medium / large scales. Output is posted to github-action-benchmark as a separate `Micro-Benchmark` chart alongside the existing end-to-end `Benchmark`. Non-NRT baselines (naive numpy padding, pickle round-trip, duplicate NRT round-trip) were dropped after the pickle entry tripped the 1.50× alert threshold on pure runner variance — they measured stdlib/numpy work unaffected by anything in this repo, so any alert on them would be noise.

## Infrastructure / hygiene

- **`numpy>=1.21`** — lowest version with `np.array_equal(equal_nan=...)` that also ships Python 3.10 wheels (matches `requires-python = ">=3.10"`).
- **`safetensors>=0.3.1`** — records the tested-against floor explicitly. The APIs we use (`safe_open(framework="np")`, `.get_tensor`, `.get_slice`, `.keys()`, `safetensors.numpy.load_file`/`save_file`) have been stable since 0.3.x.
- `uv.lock` refreshed so `uv sync --locked` in CI matches `pyproject.toml`.
- Benchmark micro-test file renamed `benchmark/test_micro.py` → `benchmark/run_micro.py` to match `benchmark/run.py`'s convention (avoids bare-`pytest` auto-collection; the benchmark workflow still runs both explicitly).

## Doctests

Extensive new doctests cover: subset happy path, default-vs-subset contrast, bounds trimming (`max_n_dims` reflects the subset), subset-contract `KeyError` in `_tensor_at_key`, all the `keys=` validation errors (bare str, non-str elements, empty iterable, reserved names, missing keys, `keys=` without `tensors_fp=`), `NaN` round-trip behavior under `==` vs `.equals(equal_nan=True)`, and subset-order determinism on `.tensors`. 100% line coverage on `src/nested_ragged_tensors/ragged_numpy.py`.

## Related merged PRs (all rolled into this release)

- #62 — initial subset-keys feature
- #64 — `.equals(equal_nan=...)` method
- #58 — core micro-benchmarks
- #66 — make subset load truly lazy
- #67 — address review feedback (validation order, subset guard, benchmark gating, baseline doctest)
- Direct commits to `dev` for the baseline tier drop and version pins