### PR TITLE
Make keys= subset load truly lazy

### DIFF
--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -357,8 +357,11 @@ class JointNestedRaggedTensorDict:
         ``dim*/k`` entries to expose, plus the ``dim*/bounds`` entries up to the deepest
         requested dimension (needed for slicing and dense reconstruction). Deeper bounds are
         skipped — they are never referenced by operations that only touch the selected keys.
-        The returned list preserves the archive's storage order, so materializing the subset
-        produces the same iteration order as a full ``load_file``.
+        The returned list preserves the archive's raw storage order as reported by
+        ``safe_open(...).keys()``, so subset materialization is deterministic relative to the
+        safetensors key order. Note that this order may differ from ``load_file(...)`` output,
+        which re-groups meta keys; matching ``load_file`` exactly would require reading every
+        tensor, which would defeat the lazy subset load.
 
         ``keys`` must be a non-empty iterable of strings. Bare ``str``/``bytes`` raise
         ``TypeError`` (so ``keys="T"`` doesn't silently iterate character-by-character). Non-str
@@ -394,7 +397,10 @@ class JointNestedRaggedTensorDict:
             needed.update(matches)
             max_requested_dim = max(max_requested_dim, *(int(k.split("/", 1)[0][3:]) for k in matches))
         if missing:
-            available = sorted({k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] != "bounds"})
+            reserved_names = set(JointNestedRaggedTensorDict._RESERVED_SUBSET_NAMES)
+            available = sorted(
+                {k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] not in reserved_names}
+            )
             raise KeyError(
                 f"Requested keys {sorted(missing)} not found in {tensors_fp}. Available: {available}"
             )

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -281,8 +281,10 @@ class JointNestedRaggedTensorDict:
             ValueError: `keys` may only be specified alongside `tensors_fp`.
 
             ``keys`` must be a non-empty iterable of strings. Bare strings are rejected (so a
-            typo like ``keys="T"`` doesn't silently iterate character-by-character), and empty
-            collections are rejected because the resulting object would have no usable tensors.
+            typo like ``keys="T"`` doesn't silently iterate character-by-character), non-str
+            elements are rejected, empty collections are rejected, and the reserved meta-names
+            ``bounds`` / ``mask`` are rejected (they refer to internal ragged-structure tensors,
+            not user-level data).
 
             >>> with tempfile.TemporaryDirectory() as dirpath:
             ...     fp = Path(dirpath) / "tensors.nrt"
@@ -298,6 +300,22 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             ValueError: `keys` must be non-empty.
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys={"A", 1})
+            Traceback (most recent call last):
+                ...
+            TypeError: `keys` must contain only strings; got elements of type ['int'].
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [[1, 2], [3]]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys={"bounds"})
+            ... # doctest: +NORMALIZE_WHITESPACE
+            Traceback (most recent call last):
+                ...
+            ValueError: `keys` may not contain reserved meta-names ['bounds'];
+                these refer to internal ragged-structure tensors, not user-level data.
         """
         args = [
             ("raw_tensors", raw_tensors),
@@ -314,7 +332,7 @@ class JointNestedRaggedTensorDict:
         if keys is not None and tensors_fp is None:
             raise ValueError("`keys` may only be specified alongside `tensors_fp`.")
 
-        self._subset_keys: set[str] | None = None
+        self._subset_keys: list[str] | None = None
         self._schema = schema if schema is not None else {}
         if raw_tensors is not None:
             self._initialize_tensors(raw_tensors)
@@ -328,28 +346,43 @@ class JointNestedRaggedTensorDict:
             if keys is not None:
                 self._subset_keys = self._resolve_subset_keys(tensors_fp, keys)
 
+    _RESERVED_SUBSET_NAMES: tuple[str, ...] = ("bounds", "mask")
+
     @staticmethod
-    def _resolve_subset_keys(tensors_fp: Path, keys: Iterable[str]) -> set[str]:
-        """Resolves the set of safetensors keys to expose for a subset load.
+    def _resolve_subset_keys(tensors_fp: Path, keys: Iterable[str]) -> list[str]:
+        """Resolves the list of safetensors keys to expose for a subset load.
 
         Opens ``tensors_fp`` for metadata only (no tensor reads). Validates that every requested
-        user-level key ``k`` maps to at least one ``dim*/k`` entry and returns the full set of
+        user-level key ``k`` maps to at least one ``dim*/k`` entry and returns the full list of
         ``dim*/k`` entries to expose, plus the ``dim*/bounds`` entries up to the deepest
         requested dimension (needed for slicing and dense reconstruction). Deeper bounds are
         skipped — they are never referenced by operations that only touch the selected keys.
-        Missing keys raise ``KeyError`` listing what is actually available.
+        The returned list preserves the archive's storage order, so materializing the subset
+        produces the same iteration order as a full ``load_file``.
 
         ``keys`` must be a non-empty iterable of strings. Bare ``str``/``bytes`` raise
-        ``TypeError`` (so ``keys="T"`` doesn't silently iterate character-by-character), and an
-        empty iterable raises ``ValueError``.
+        ``TypeError`` (so ``keys="T"`` doesn't silently iterate character-by-character). Non-str
+        elements also raise ``TypeError``. Reserved meta-names (``bounds``, ``mask``) are
+        rejected with ``ValueError``. An empty iterable raises ``ValueError``. Missing keys
+        raise ``KeyError`` listing what is actually available.
         """
         if isinstance(keys, (str, bytes)):
             raise TypeError("`keys` must be an iterable of strings, not a bare str/bytes.")
         requested = set(keys)
         if not requested:
             raise ValueError("`keys` must be non-empty.")
+        bad_types = sorted({type(k).__name__ for k in requested if not isinstance(k, str)})
+        if bad_types:
+            raise TypeError(f"`keys` must contain only strings; got elements of type {bad_types}.")
+        reserved = requested & set(JointNestedRaggedTensorDict._RESERVED_SUBSET_NAMES)
+        if reserved:
+            raise ValueError(
+                f"`keys` may not contain reserved meta-names {sorted(reserved)}; these refer "
+                "to internal ragged-structure tensors, not user-level data."
+            )
         with safe_open(tensors_fp, framework="np") as f:
-            stored = set(f.keys())
+            stored_order = list(f.keys())
+        stored = set(stored_order)
         needed: set[str] = set()
         missing: set[str] = set()
         max_requested_dim = -1
@@ -370,7 +403,7 @@ class JointNestedRaggedTensorDict:
             for k in stored
             if k.split("/", 1)[1] == "bounds" and int(k.split("/", 1)[0][3:]) <= max_requested_dim
         )
-        return needed
+        return [k for k in stored_order if k in needed]
 
     def __eq__(self, other: object) -> bool:
         """Checks if this JointNestedRaggedTensorDict is equal to another object.
@@ -475,7 +508,9 @@ class JointNestedRaggedTensorDict:
 
         Loads from disk on first access when backed by ``tensors_fp``. When the instance was
         constructed with ``keys=``, only the resolved subset is loaded — the unselected entries
-        are never read.
+        are never read. Iteration order of the returned dict is the archive's raw storage order
+        (as reported by ``safe_open().keys()``) filtered to the subset, so it is deterministic
+        across runs rather than depending on set-hash iteration.
 
         Examples:
             >>> import tempfile
@@ -485,8 +520,8 @@ class JointNestedRaggedTensorDict:
             ...         "T":  [[1, 2, 3], [4, 5]],
             ...         "id": [[[1, 2, 3], [3, 4], [1, 2]], [[3], [3, 2, 2]]],
             ...     }).save(fp)
-            ...     sub = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"})
-            ...     sorted(sub.tensors.keys())
+            ...     sub = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"}).tensors
+            ...     list(sub)
             ['dim1/T', 'dim1/bounds']
         """
         if self._tensors is None:

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -167,12 +167,15 @@ class JointNestedRaggedTensorDict:
             processed_tensors: The tensors to be stored, in pre-processed format.
             tensors_fp: The filepath from which to load the pre-processed tensors in safetensors format.
             schema: The schema for the tensors, if known.
-            keys: Restricts the subset of user-level keys loaded from ``tensors_fp``. Only valid when
-                ``tensors_fp`` is provided. When supplied, the backing safetensors archive is opened
-                lazily and only the ``dim*/{k}`` entries for the requested keys are read into memory
-                (the ``dim*/bounds`` entries required for dense reconstruction are always kept).
-                Operations that only reference the loaded keys work unchanged; operations that
-                touch a non-loaded key raise a ``KeyError``.
+            keys: Restricts the subset of user-level keys visible from ``tensors_fp``. Only valid
+                when ``tensors_fp`` is provided. When supplied, the backing safetensors archive
+                is opened at init only long enough to validate the requested keys and determine
+                which ``dim*/bounds`` entries are required; no tensor values are read until an
+                operation actually needs them. Subsequent reads happen lazily through
+                ``safe_open`` and only touch the ``dim*/{k}`` entries for the requested keys (or
+                the required ``dim*/bounds``). Operations that reference a non-selected key
+                raise ``KeyError``. ``keys`` must be a non-empty iterable of strings; passing a
+                bare ``str``/``bytes`` raises ``TypeError``.
 
         Examples:
             >>> import tempfile
@@ -276,6 +279,25 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             ValueError: `keys` may only be specified alongside `tensors_fp`.
+
+            ``keys`` must be a non-empty iterable of strings. Bare strings are rejected (so a
+            typo like ``keys="T"`` doesn't silently iterate character-by-character), and empty
+            collections are rejected because the resulting object would have no usable tensors.
+
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys="A")
+            Traceback (most recent call last):
+                ...
+            TypeError: `keys` must be an iterable of strings, not a bare str/bytes.
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({"A": [1, 2, 3]}).save(fp)
+            ...     JointNestedRaggedTensorDict(tensors_fp=fp, keys=[])
+            Traceback (most recent call last):
+                ...
+            ValueError: `keys` must be non-empty.
         """
         args = [
             ("raw_tensors", raw_tensors),
@@ -292,6 +314,7 @@ class JointNestedRaggedTensorDict:
         if keys is not None and tensors_fp is None:
             raise ValueError("`keys` may only be specified alongside `tensors_fp`.")
 
+        self._subset_keys: set[str] | None = None
         self._schema = schema if schema is not None else {}
         if raw_tensors is not None:
             self._initialize_tensors(raw_tensors)
@@ -301,45 +324,53 @@ class JointNestedRaggedTensorDict:
             if not tensors_fp.is_file():
                 raise FileNotFoundError(f"Tensors filepath must exist, got {tensors_fp}")
             self._tensors_fp = tensors_fp
-            if keys is None:
-                self._tensors = None
-            else:
-                self._tensors = self._load_subset(tensors_fp, keys)
+            self._tensors = None
+            if keys is not None:
+                self._subset_keys = self._resolve_subset_keys(tensors_fp, keys)
 
     @staticmethod
-    def _load_subset(tensors_fp: Path, keys: Iterable[str]) -> dict[str, np.ndarray]:
-        """Eagerly reads a user-requested subset of user-level keys from a safetensors archive.
+    def _resolve_subset_keys(tensors_fp: Path, keys: Iterable[str]) -> set[str]:
+        """Resolves the set of safetensors keys to expose for a subset load.
 
-        For each requested user-level key ``k``, the matching ``dim*/k`` entry is read. The
-        ``dim*/bounds`` entries up to the deepest requested key's dimension are also loaded
-        because they are required for slicing and dense reconstruction. Bounds for deeper dims
-        are skipped — they are never referenced by operations that only touch the loaded keys.
-        Missing keys raise a ``KeyError`` that lists what is actually available in the file.
+        Opens ``tensors_fp`` for metadata only (no tensor reads). Validates that every requested
+        user-level key ``k`` maps to at least one ``dim*/k`` entry and returns the full set of
+        ``dim*/k`` entries to expose, plus the ``dim*/bounds`` entries up to the deepest
+        requested dimension (needed for slicing and dense reconstruction). Deeper bounds are
+        skipped — they are never referenced by operations that only touch the selected keys.
+        Missing keys raise ``KeyError`` listing what is actually available.
+
+        ``keys`` must be a non-empty iterable of strings. Bare ``str``/``bytes`` raise
+        ``TypeError`` (so ``keys="T"`` doesn't silently iterate character-by-character), and an
+        empty iterable raises ``ValueError``.
         """
+        if isinstance(keys, (str, bytes)):
+            raise TypeError("`keys` must be an iterable of strings, not a bare str/bytes.")
         requested = set(keys)
+        if not requested:
+            raise ValueError("`keys` must be non-empty.")
         with safe_open(tensors_fp, framework="np") as f:
             stored = set(f.keys())
-            needed = set()
-            missing = set()
-            max_requested_dim = -1
-            for req in requested:
-                matches = {k for k in stored if k.split("/", 1)[1] == req}
-                if not matches:
-                    missing.add(req)
-                    continue
-                needed.update(matches)
-                max_requested_dim = max(max_requested_dim, *(int(k.split("/", 1)[0][3:]) for k in matches))
-            if missing:
-                available = sorted({k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] != "bounds"})
-                raise KeyError(
-                    f"Requested keys {sorted(missing)} not found in {tensors_fp}. Available: {available}"
-                )
-            needed.update(
-                k
-                for k in stored
-                if k.split("/", 1)[1] == "bounds" and int(k.split("/", 1)[0][3:]) <= max_requested_dim
+        needed: set[str] = set()
+        missing: set[str] = set()
+        max_requested_dim = -1
+        for req in requested:
+            matches = {k for k in stored if k.split("/", 1)[1] == req}
+            if not matches:
+                missing.add(req)
+                continue
+            needed.update(matches)
+            max_requested_dim = max(max_requested_dim, *(int(k.split("/", 1)[0][3:]) for k in matches))
+        if missing:
+            available = sorted({k.split("/", 1)[1] for k in stored if k.split("/", 1)[1] != "bounds"})
+            raise KeyError(
+                f"Requested keys {sorted(missing)} not found in {tensors_fp}. Available: {available}"
             )
-            return {k: f.get_tensor(k) for k in needed}
+        needed.update(
+            k
+            for k in stored
+            if k.split("/", 1)[1] == "bounds" and int(k.split("/", 1)[0][3:]) <= max_requested_dim
+        )
+        return needed
 
     def __eq__(self, other: object) -> bool:
         """Checks if this JointNestedRaggedTensorDict is equal to another object.
@@ -441,16 +472,21 @@ class JointNestedRaggedTensorDict:
     @property
     def tensors(self) -> dict[str, np.ndarray]:
         if self._tensors is None:
-            self._tensors = load_file(self._tensors_fp)
+            if self._subset_keys is not None:
+                with safe_open(self._tensors_fp, framework="np") as f:
+                    self._tensors = {k: f.get_tensor(k) for k in self._subset_keys}
+            else:
+                self._tensors = load_file(self._tensors_fp)
         return self._tensors
 
     @cached_property
     def _tensor_keys(self) -> set[str]:
-        if self._tensors is None:
-            with safe_open(self._tensors_fp, framework="np") as f:
-                return set(f.keys())
-        else:
+        if self._tensors is not None:
             return set(self._tensors.keys())
+        if self._subset_keys is not None:
+            return set(self._subset_keys)
+        with safe_open(self._tensors_fp, framework="np") as f:
+            return set(f.keys())
 
     @contextmanager
     def _tensor_at_key(self, key: str):

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -471,6 +471,24 @@ class JointNestedRaggedTensorDict:
 
     @property
     def tensors(self) -> dict[str, np.ndarray]:
+        """Materialized dict of all stored tensors, keyed as ``dim*/name``.
+
+        Loads from disk on first access when backed by ``tensors_fp``. When the instance was
+        constructed with ``keys=``, only the resolved subset is loaded — the unselected entries
+        are never read.
+
+        Examples:
+            >>> import tempfile
+            >>> with tempfile.TemporaryDirectory() as dirpath:
+            ...     fp = Path(dirpath) / "tensors.nrt"
+            ...     JointNestedRaggedTensorDict({
+            ...         "T":  [[1, 2, 3], [4, 5]],
+            ...         "id": [[[1, 2, 3], [3, 4], [1, 2]], [[3], [3, 2, 2]]],
+            ...     }).save(fp)
+            ...     sub = JointNestedRaggedTensorDict(tensors_fp=fp, keys={"T"})
+            ...     sorted(sub.tensors.keys())
+            ['dim1/T', 'dim1/bounds']
+        """
         if self._tensors is None:
             if self._subset_keys is not None:
                 with safe_open(self._tensors_fp, framework="np") as f:


### PR DESCRIPTION
## Summary
Addresses https://github.com/mmcdermott/nested_ragged_tensors/pull/65#discussion_r3102799565 — the `keys=` subset load was eagerly reading every selected tensor into memory at init time, which defeated the main motivation of the feature.

- `__init__` now validates `keys=` against file metadata only (`safe_open().keys()`), resolves the required `dim*/bounds` entries, and stores the resolved set on `self._subset_keys`. **No tensor values are read.**
- `self._tensors` stays `None` for subset loads, so existing lazy paths (`_tensor_at_key` via `safe_open`) just work — callers that only touch a single key never pay for the rest.
- `_tensor_keys` returns the subset when `_subset_keys` is set.
- The `.tensors` property (the last eager materializer) loads only the subset via `safe_open + get_tensor` when `_subset_keys` is set, rather than `load_file`'ing the whole archive.

Also addresses two Copilot review points on #65:
- `keys=<str|bytes>` now raises `TypeError` instead of silently iterating character-by-character.
- `keys=[]` (or any empty iterable) now raises `ValueError` instead of returning an object with no usable tensors.

Doctests cover the new validation errors and the lazy-read path.

## Test plan
- [x] `uv run pytest --doctest-modules src/nested_ragged_tensors/ragged_numpy.py` passes locally
- [x] `uv run python -m doctest README.md` passes
- [x] `uv run pre-commit run --files src/nested_ragged_tensors/ragged_numpy.py` passes
- [x] Manual lazy-behavior check: after init, `_tensors is None`; after `_tensor_at_key(...)` read, still `None`; only touching `.tensors` materializes, and then only the subset.
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)