### PR TITLE
Use enumerate in _slice_single squeeze-dim loop

### DIFF
--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1789,10 +1789,8 @@ class JointNestedRaggedTensorDict:
 
         out = self.__class__(processed_tensors=tensors, schema=schema)
         if squeeze_dims is not None:
-            i = 0
-            for dim in sorted(squeeze_dims):
+            for i, dim in enumerate(sorted(squeeze_dims)):
                 out = out.squeeze(dim - i)
-                i += 1
         return out
 
     def _slice(


### PR DESCRIPTION
## Summary

- Cosmetic refactor flagged by ruff SIM113 in #36: replace manual index tracking with `enumerate` in the `_slice_single` squeeze-dim loop.
- No behavior change — the loop is equivalent.

Closes #36.

## Test plan

- [x] Full doctest suite passes locally (`pytest --doctest-modules src/nested_ragged_tensors/ragged_numpy.py`).
- [x] CI (tests, code-quality, benchmark) green.