### PR TITLE
Reject reserved meta-names (bounds/mask) in raw-input constructor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ benchmarks = ["ml-mixins", "torch", "rootutils", "memray"]
 
 [tool.setuptools_scm]
 
+[tool.pytest.ini_options]
+# Default flags applied to every doctest. NORMALIZE_WHITESPACE lets expected-output
+# lines wrap naturally; ELLIPSIS lets `...` stand in for variable paths / numbers.
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+
 [project.optional-dependencies]
 docs = [
   "mkdocs>=1.6.1", "mkdocs-material>=9.5.31", "mkdocstrings[python]>=0.26", "mkdocs-gen-files>=0.5",

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -824,7 +824,35 @@ class JointNestedRaggedTensorDict:
         raise ValueError("Vals must all be ints, floats, or bools")
 
     def _initialize_tensors(self, tensors: dict[str, list[NESTED_NUM_LIST_T] | NESTED_NUM_LIST_T]):
-        """Initializes the tensors from lists of raw data entries."""
+        """Initializes the tensors from lists of raw data entries.
+
+        Reserved meta-names (``bounds``, ``mask``) are rejected here. They collide with
+        internal ragged-structure tensor names (``dim{N}/bounds`` / ``dim{N}/mask``) that
+        the class uses to track per-dimension lengths and densification masks. Allowing
+        them silently corrupted the tensor dict — ``to_dense()`` would drop the key, or
+        the auto-generated ``dim{N}/bounds`` would clash with user data — see #42.
+
+        Examples:
+            >>> JointNestedRaggedTensorDict({"bounds": [1, 2, 3]})
+            Traceback (most recent call last):
+                ...
+            ValueError: Reserved meta-names ['bounds'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.
+            >>> JointNestedRaggedTensorDict({"mask": [[1, 2, 3]]})
+            Traceback (most recent call last):
+                ...
+            ValueError: Reserved meta-names ['mask'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.
+            >>> JointNestedRaggedTensorDict({"T": [1, 2], "bounds": [3, 4], "mask": [5, 6]})
+            Traceback (most recent call last):
+                ...
+            ValueError: Reserved meta-names ['bounds', 'mask'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.
+        """
+        reserved = set(self._RESERVED_SUBSET_NAMES) & set(tensors)
+        if reserved:
+            raise ValueError(
+                f"Reserved meta-names {sorted(reserved)} cannot be used as user tensor "
+                "names; they collide with internal ragged-structure tensors."
+            )
+
         self._tensors = {}
         for k, T in tensors.items():
             if len(T) == 0:

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -834,19 +834,16 @@ class JointNestedRaggedTensorDict:
 
         Examples:
             >>> JointNestedRaggedTensorDict({"bounds": [1, 2, 3]})
-            ... # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
                 ...
             ValueError: Reserved meta-names ['bounds'] cannot be used as user tensor names;
                 they collide with internal ragged-structure tensors.
             >>> JointNestedRaggedTensorDict({"mask": [[1, 2, 3]]})
-            ... # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
                 ...
             ValueError: Reserved meta-names ['mask'] cannot be used as user tensor names;
                 they collide with internal ragged-structure tensors.
             >>> JointNestedRaggedTensorDict({"T": [1, 2], "bounds": [3, 4], "mask": [5, 6]})
-            ... # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
                 ...
             ValueError: Reserved meta-names ['bounds', 'mask'] cannot be used as user tensor names;

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -834,17 +834,23 @@ class JointNestedRaggedTensorDict:
 
         Examples:
             >>> JointNestedRaggedTensorDict({"bounds": [1, 2, 3]})
+            ... # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
                 ...
-            ValueError: Reserved meta-names ['bounds'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.
+            ValueError: Reserved meta-names ['bounds'] cannot be used as user tensor names;
+                they collide with internal ragged-structure tensors.
             >>> JointNestedRaggedTensorDict({"mask": [[1, 2, 3]]})
+            ... # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
                 ...
-            ValueError: Reserved meta-names ['mask'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.
+            ValueError: Reserved meta-names ['mask'] cannot be used as user tensor names;
+                they collide with internal ragged-structure tensors.
             >>> JointNestedRaggedTensorDict({"T": [1, 2], "bounds": [3, 4], "mask": [5, 6]})
+            ... # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
                 ...
-            ValueError: Reserved meta-names ['bounds', 'mask'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.
+            ValueError: Reserved meta-names ['bounds', 'mask'] cannot be used as user tensor names;
+                they collide with internal ragged-structure tensors.
         """
         reserved = set(self._RESERVED_SUBSET_NAMES) & set(tensors)
         if reserved:


### PR DESCRIPTION
## Summary

Closes #42.

Users passing a tensor named `bounds` or `mask` via the raw-input constructor hit silent corruption. Probes:

```python
# Silent: to_dense drops user data
J = JointNestedRaggedTensorDict({"bounds": [1, 2, 3]})
J.to_dense()  # {}

# Silent: mask key collides with internal dim1/mask naming
J = JointNestedRaggedTensorDict({"mask": [[1, 2, 3]]})
J.to_dense()  # {}

# Cryptic: user's bounds conflated with auto-generated dim1/bounds
JointNestedRaggedTensorDict({"bounds": [[1,2], [3]], "other": [[1,2], [3]]})
# ValueError: Inconsistent bounds tensors! [1 2 3] vs. [2 3]
```

The subset-load path (#60, #66) already guards this via `_RESERVED_SUBSET_NAMES = ("bounds", "mask")`. This PR adds the same check to `_initialize_tensors` so raw-input construction fails fast with a clear error:

> `Reserved meta-names ['bounds'] cannot be used as user tensor names; they collide with internal ragged-structure tensors.`

## Test plan

- [x] Three new doctests lock in the rejection behavior for `bounds`, `mask`, and mixed cases.
- [x] 100% coverage maintained; existing doctest suite passes.
- [ ] CI green.

## Breaking change

Technically breaking for any caller literally using `bounds` or `mask` as a tensor name. In practice they were already getting silent corruption or cryptic errors, so no one can be relying on correctness — the fix converts that to a loud error at the earliest possible point. Should be called out in release notes.