### PR TITLE
Raise IndexError on out-of-range int indexing (recursive across all dims)

### DIFF
--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1127,11 +1127,11 @@ class JointNestedRaggedTensorDict:
             >>> J[5]
             Traceback (most recent call last):
                 ...
-            IndexError: Index 5 is out of range for JointNestedRaggedTensorDict of length 3.
+            IndexError: Index 5 is out of range at dim 0 (length 3).
             >>> J[-4]
             Traceback (most recent call last):
                 ...
-            IndexError: Index -4 is out of range for JointNestedRaggedTensorDict of length 3.
+            IndexError: Index -4 is out of range at dim 0 (length 3).
             >>> J[5:10].tensors['dim0/T']
             array([], dtype=uint8)
 
@@ -1176,6 +1176,17 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             IndexError: Index 2 is out of range at dim 2 (length 1).
+
+        Passing more ints than the JNRT has dimensions is a clean ``IndexError``
+        rather than a surprise ``TypeError`` from None-arithmetic:
+
+            >>> J2 = JointNestedRaggedTensorDict({"T": [[1, 2], [3]]})
+            >>> J2.max_n_dims
+            2
+            >>> J2[0, 0, 0]
+            Traceback (most recent call last):
+                ...
+            IndexError: Too many indices for JointNestedRaggedTensorDict: got 3 indices but max_n_dims is 2.
         """
         return self._slice(self._get_slice_indices(idx))
 
@@ -2061,7 +2072,8 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             TypeError: <class 'list'> not supported for JointNestedRaggedTensorDict slicing
-            >>> J._get_slice_indices((1, 2.4))
+            >>> J2 = JointNestedRaggedTensorDict({"T": [[1, 2, 3], [4, 5]]})
+            >>> J2._get_slice_indices((0, 2.4))
             Traceback (most recent call last):
                 ...
             TypeError: <class 'float'> at index 1 not supported for JointNestedRaggedTensorDict tuple slicing
@@ -2089,6 +2101,15 @@ class JointNestedRaggedTensorDict:
                 for dim, idx in enumerate(T):
                     if seen_non_int:
                         raise ValueError("Multi-level non-int slicing is not supported.")
+
+                    if current_length is None:
+                        # _row_length_from_out_indices returned None because we've
+                        # exhausted the ragged structure — the tuple has more ints
+                        # than the JNRT has dimensions. Match numpy's error shape.
+                        raise IndexError(
+                            f"Too many indices for {self.__class__.__name__}: got "
+                            f"{len(T)} indices but max_n_dims is {self.max_n_dims}."
+                        )
 
                     if isinstance(idx, int):
                         if not -current_length <= idx < current_length:
@@ -2121,8 +2142,12 @@ class JointNestedRaggedTensorDict:
         Out-of-range int indexing previously silently returned an empty JNRT (positive
         index) or raised a cryptic internal ``IndexError`` (negative index, see #52);
         this method replaces both with a clean ``IndexError`` matching Python/numpy
-        list semantics. Only dim-0 is covered here; see ``_check_dim1_int_index`` for
-        the dim-1 analogue in multi-dim tuple slicing.
+        list semantics. Only dim-0 is handled here; dim>0 bounds checks for
+        multi-dim tuple slicing are computed inline in ``_get_slice_indices`` using
+        ``_row_length_from_out_indices`` for the current row length at each depth.
+        The error message format matches the dim>0 wording so callers see the same
+        ``"Index X is out of range at dim D (length N)"`` pattern regardless of which
+        dim failed.
 
         Examples:
             >>> J = JointNestedRaggedTensorDict({"T": [1, 2, 3]})
@@ -2137,15 +2162,15 @@ class JointNestedRaggedTensorDict:
             >>> J._check_int_index(3)
             Traceback (most recent call last):
                 ...
-            IndexError: Index 3 is out of range for JointNestedRaggedTensorDict of length 3.
+            IndexError: Index 3 is out of range at dim 0 (length 3).
             >>> J._check_int_index(-4)
             Traceback (most recent call last):
                 ...
-            IndexError: Index -4 is out of range for JointNestedRaggedTensorDict of length 3.
+            IndexError: Index -4 is out of range at dim 0 (length 3).
         """
         n = len(self)
         if not -n <= i < n:
-            raise IndexError(f"Index {i} is out of range for {self.__class__.__name__} of length {n}.")
+            raise IndexError(f"Index {i} is out of range at dim 0 (length {n}).")
         return i if i >= 0 else i + n
 
     def _row_length_from_out_indices(self, out_indices: dict, dim: int) -> int | None:

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -2192,10 +2192,11 @@ class JointNestedRaggedTensorDict:
             >>> out = J._get_slice_indices_internal(slice(1, 2), 0, {})
             >>> J._row_length_from_out_indices(out, 1)
             2
-            >>> J._row_length_from_out_indices(out, 5)  # past max_n_dims
+            >>> print(J._row_length_from_out_indices(out, 5))  # past max_n_dims
+            None
 
-            Fallback path: if a dim has no data keys, row length is derived
-            from the bounds slice + bounds tensor.
+            Fallback path — when a dim has no data keys, the row length is derived
+            from the bounds slice plus the bounds tensor itself:
 
             >>> J_nodata_dim1 = JointNestedRaggedTensorDict({"id": [[[1, 2], [3]], [[4]]]})
             >>> J_nodata_dim1.keys_at_dim(1)

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -2081,10 +2081,10 @@ class JointNestedRaggedTensorDict:
 
         match idx:
             case np.ndarray() as arr if arr.dtype in (NP_INT_TYPES + NP_UINT_TYPES) and arr.ndim == 1:
-                normalized = [self._check_int_index(int(i)) for i in arr]
+                normalized = [self._bounds_check_int(int(i), len(self), 0) for i in arr]
                 return [self._get_slice_indices(slice(i, i + 1)) for i in normalized]
             case int() as i:
-                i = self._check_int_index(i)
+                i = self._bounds_check_int(i, len(self), 0)
                 return (self._get_slice_indices(slice(i, i + 1)), [0])
             case tuple() as T:
                 squeeze_dims = []
@@ -2112,12 +2112,7 @@ class JointNestedRaggedTensorDict:
                         )
 
                     if isinstance(idx, int):
-                        if not -current_length <= idx < current_length:
-                            raise IndexError(
-                                f"Index {idx} is out of range at dim {dim} " f"(length {current_length})."
-                            )
-                        if idx < 0:
-                            idx += current_length
+                        idx = self._bounds_check_int(idx, current_length, dim)
                         idx = slice(idx, idx + 1)
                         squeeze_dims.append(dim)
                     else:
@@ -2136,42 +2131,41 @@ class JointNestedRaggedTensorDict:
             case _:
                 raise TypeError(f"{type(idx)} not supported for {self.__class__.__name__} slicing")
 
-    def _check_int_index(self, i: int) -> int:
-        """Bounds-check and normalize a dim-0 integer index.
+    @staticmethod
+    def _bounds_check_int(idx: int, length: int, dim: int) -> int:
+        """Bounds-check and normalize an integer index against a given ``length``.
 
-        Out-of-range int indexing previously silently returned an empty JNRT (positive
-        index) or raised a cryptic internal ``IndexError`` (negative index, see #52);
-        this method replaces both with a clean ``IndexError`` matching Python/numpy
-        list semantics. Only dim-0 is handled here; dim>0 bounds checks for
-        multi-dim tuple slicing are computed inline in ``_get_slice_indices`` using
-        ``_row_length_from_out_indices`` for the current row length at each depth.
-        The error message format matches the dim>0 wording so callers see the same
-        ``"Index X is out of range at dim D (length N)"`` pattern regardless of which
-        dim failed.
+        Used for int-index bounds checks at every dim (dim-0 via ``len(self)``,
+        dim>0 via the row length derived from ``_row_length_from_out_indices``).
+        Raises ``IndexError`` with the uniform ``"Index X is out of range at dim D
+        (length N)"`` format, so callers see identical wording regardless of which
+        dim failed. Returns the normalized (non-negative) index.
 
         Examples:
-            >>> J = JointNestedRaggedTensorDict({"T": [1, 2, 3]})
-            >>> J._check_int_index(0)
+            >>> JointNestedRaggedTensorDict._bounds_check_int(0, 3, 0)
             0
-            >>> J._check_int_index(2)
+            >>> JointNestedRaggedTensorDict._bounds_check_int(2, 3, 0)
             2
-            >>> J._check_int_index(-1)
+            >>> JointNestedRaggedTensorDict._bounds_check_int(-1, 3, 0)
             2
-            >>> J._check_int_index(-3)
+            >>> JointNestedRaggedTensorDict._bounds_check_int(-3, 3, 0)
             0
-            >>> J._check_int_index(3)
+            >>> JointNestedRaggedTensorDict._bounds_check_int(3, 3, 0)
             Traceback (most recent call last):
                 ...
             IndexError: Index 3 is out of range at dim 0 (length 3).
-            >>> J._check_int_index(-4)
+            >>> JointNestedRaggedTensorDict._bounds_check_int(-4, 3, 0)
             Traceback (most recent call last):
                 ...
             IndexError: Index -4 is out of range at dim 0 (length 3).
+            >>> JointNestedRaggedTensorDict._bounds_check_int(5, 2, 1)
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 5 is out of range at dim 1 (length 2).
         """
-        n = len(self)
-        if not -n <= i < n:
-            raise IndexError(f"Index {i} is out of range at dim 0 (length {n}).")
-        return i if i >= 0 else i + n
+        if not -length <= idx < length:
+            raise IndexError(f"Index {idx} is out of range at dim {dim} (length {length}).")
+        return idx if idx >= 0 else idx + length
 
     def _row_length_from_out_indices(self, out_indices: dict, dim: int) -> int | None:
         """Row length at ``dim`` given the current tuple-slice resolution state.

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1134,6 +1134,48 @@ class JointNestedRaggedTensorDict:
             IndexError: Index -4 is out of range for JointNestedRaggedTensorDict of length 3.
             >>> J[5:10].tensors['dim0/T']
             array([], dtype=uint8)
+
+        Tuple int indexing is bounds-checked at every dim, not just dim 0. The
+        length available at each dim is the row length already selected by previous
+        ints; the error names the dim and that length.
+
+            >>> J = JointNestedRaggedTensorDict({
+            ...     "T": [1, 2, 3],
+            ...     "id": [[1, 2, 3], [3, 4], [1, 2]],
+            ... })
+            >>> J[0, 3]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 3 is out of range at dim 1 (length 3).
+            >>> J[1, 2]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 2 is out of range at dim 1 (length 2).
+            >>> J[1, -5]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index -5 is out of range at dim 1 (length 2).
+            >>> J[0, -1].tensors['dim-1/id']  # valid negative dim-1 index normalizes
+            array([3], dtype=uint8)
+
+        Works recursively at arbitrary depth — here dim 2 indexing is bounds-
+        checked against the currently-selected (dim-0, dim-1) row:
+
+            >>> J3 = JointNestedRaggedTensorDict({
+            ...     "T":   [[1,           2       ], [4  ]],
+            ...     "id":  [[[1, 2, 3],   [3,   4]], [[3]]],
+            ...     "val": [[[1, 0.2, 0], [3.1, 0]], [[3]]],
+            ... }, schema={"T": int, "id": int, "val": float})
+            >>> J3[0, 0, 2].tensors['dim-1/val']  # row (0, 0) has 3 elements — valid
+            array([0.])
+            >>> J3[0, 0, 5]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 5 is out of range at dim 2 (length 3).
+            >>> J3[1, 0, 2]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 2 is out of range at dim 2 (length 1).
         """
         return self._slice(self._get_slice_indices(idx))
 
@@ -2036,13 +2078,25 @@ class JointNestedRaggedTensorDict:
                 squeeze_dims = []
                 out_indices = {}
                 seen_non_int = False
+                # Track the length available to the next int bounds check. At dim 0
+                # this is len(self); at deeper dims it is the currently-selected
+                # row's length, which we derive from out_indices after each call to
+                # _get_slice_indices_internal. The internal already walks bounds
+                # recursively to translate (st, end) from dim D to dim D+1, so
+                # reading out_indices here reuses that state rather than duplicating
+                # the recursion.
+                current_length = len(self)
                 for dim, idx in enumerate(T):
                     if seen_non_int:
                         raise ValueError("Multi-level non-int slicing is not supported.")
 
                     if isinstance(idx, int):
-                        if dim == 0:
-                            idx = self._check_int_index(idx)
+                        if not -current_length <= idx < current_length:
+                            raise IndexError(
+                                f"Index {idx} is out of range at dim {dim} " f"(length {current_length})."
+                            )
+                        if idx < 0:
+                            idx += current_length
                         idx = slice(idx, idx + 1)
                         squeeze_dims.append(dim)
                     else:
@@ -2054,6 +2108,7 @@ class JointNestedRaggedTensorDict:
                             f"{self.__class__.__name__} tuple slicing"
                         )
                     out_indices = self._get_slice_indices_internal(idx, dim, out_indices)
+                    current_length = self._row_length_from_out_indices(out_indices, dim + 1)
                 return (out_indices, squeeze_dims)
             case slice() as S:
                 return self._get_slice_indices_internal(S, 0, {})
@@ -2066,8 +2121,8 @@ class JointNestedRaggedTensorDict:
         Out-of-range int indexing previously silently returned an empty JNRT (positive
         index) or raised a cryptic internal ``IndexError`` (negative index, see #52);
         this method replaces both with a clean ``IndexError`` matching Python/numpy
-        list semantics. Only dim-0 is covered here — deeper-dim int bounds depend on
-        per-row lengths in a ragged tensor and are out of scope for this check.
+        list semantics. Only dim-0 is covered here; see ``_check_dim1_int_index`` for
+        the dim-1 analogue in multi-dim tuple slicing.
 
         Examples:
             >>> J = JointNestedRaggedTensorDict({"T": [1, 2, 3]})
@@ -2092,6 +2147,66 @@ class JointNestedRaggedTensorDict:
         if not -n <= i < n:
             raise IndexError(f"Index {i} is out of range for {self.__class__.__name__} of length {n}.")
         return i if i >= 0 else i + n
+
+    def _row_length_from_out_indices(self, out_indices: dict, dim: int) -> int | None:
+        """Row length at ``dim`` given the current tuple-slice resolution state.
+
+        Used by tuple int-index bounds checking at any depth. After
+        ``_get_slice_indices_internal`` resolves a slice at dim D, ``out_indices``
+        already encodes the row selected by previous ints via flat slices for
+        dim D (and deeper). The length of that row at ``dim`` is ``stop - start``
+        of any data-key slice at that dim; if there are no data keys at ``dim``,
+        it's derived from the bounds slice + bounds array.
+
+        Returns ``None`` when ``dim >= self.max_n_dims`` (no further int bounds
+        checks are possible — the tuple has run off the end of the ragged
+        structure).
+
+        Examples:
+            >>> J = JointNestedRaggedTensorDict({
+            ...     "T": [1, 2, 3],
+            ...     "id": [[1, 2, 3], [3, 4], [1, 2]],
+            ... })
+            >>> out = J._get_slice_indices_internal(slice(0, 1), 0, {})
+            >>> J._row_length_from_out_indices(out, 1)
+            3
+            >>> out = J._get_slice_indices_internal(slice(1, 2), 0, {})
+            >>> J._row_length_from_out_indices(out, 1)
+            2
+            >>> J._row_length_from_out_indices(out, 5)  # past max_n_dims
+
+            Fallback path: if a dim has no data keys, row length is derived
+            from the bounds slice + bounds tensor.
+
+            >>> J_nodata_dim1 = JointNestedRaggedTensorDict({"id": [[[1, 2], [3]], [[4]]]})
+            >>> J_nodata_dim1.keys_at_dim(1)
+            set()
+            >>> out = J_nodata_dim1._get_slice_indices_internal(slice(0, 1), 0, {})
+            >>> J_nodata_dim1._row_length_from_out_indices(out, 1)
+            2
+        """
+        if dim >= self.max_n_dims:
+            return None
+        for key in self.keys_at_dim(dim):
+            s = out_indices.get(f"dim{dim}/{key}")
+            if isinstance(s, slice):
+                return int((s.stop or 0) - (s.start or 0))
+        bounds_slice = out_indices.get(f"dim{dim}/bounds")
+        if not isinstance(bounds_slice, slice):  # pragma: no cover
+            return None
+        bst = bounds_slice.start or 0
+        bend = bounds_slice.stop
+        with self._tensor_at_key(f"dim{dim}/bounds") as bounds:
+            if bend is None:  # pragma: no cover  # tuple-slice path always sets stop
+                try:
+                    bend = bounds.get_shape()[0]
+                except Exception:
+                    bend = len(bounds)
+            if bend <= bst:  # pragma: no cover  # empty bounds slice — defensive
+                return 0
+            start_flat = int(bounds[bst - 1]) if bst > 0 else 0
+            end_flat = int(bounds[bend - 1])
+        return end_flat - start_flat
 
     def _get_slice_indices_internal(
         self, idx: slice, starting_dim: int, curr_indices: dict[str, slice]

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1118,6 +1118,22 @@ class JointNestedRaggedTensorDict:
             Traceback (most recent call last):
                 ...
             ValueError: Multi-level non-int slicing is not supported.
+
+        Out-of-range int indexing raises ``IndexError`` (matches Python/numpy
+        semantics, see #52). Out-of-range *slice* indexing still clips to size
+        and returns an empty view, matching numpy slicing.
+
+            >>> J = JointNestedRaggedTensorDict({"T": [1, 2, 3]})
+            >>> J[5]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 5 is out of range for JointNestedRaggedTensorDict of length 3.
+            >>> J[-4]
+            Traceback (most recent call last):
+                ...
+            IndexError: Index -4 is out of range for JointNestedRaggedTensorDict of length 3.
+            >>> J[5:10].tensors['dim0/T']
+            array([], dtype=uint8)
         """
         return self._slice(self._get_slice_indices(idx))
 
@@ -2011,8 +2027,10 @@ class JointNestedRaggedTensorDict:
 
         match idx:
             case np.ndarray() as arr if arr.dtype in (NP_INT_TYPES + NP_UINT_TYPES) and arr.ndim == 1:
-                return [self._get_slice_indices(slice(i, i + 1)) for i in arr]
+                normalized = [self._check_int_index(int(i)) for i in arr]
+                return [self._get_slice_indices(slice(i, i + 1)) for i in normalized]
             case int() as i:
+                i = self._check_int_index(i)
                 return (self._get_slice_indices(slice(i, i + 1)), [0])
             case tuple() as T:
                 squeeze_dims = []
@@ -2023,6 +2041,8 @@ class JointNestedRaggedTensorDict:
                         raise ValueError("Multi-level non-int slicing is not supported.")
 
                     if isinstance(idx, int):
+                        if dim == 0:
+                            idx = self._check_int_index(idx)
                         idx = slice(idx, idx + 1)
                         squeeze_dims.append(dim)
                     else:
@@ -2039,6 +2059,39 @@ class JointNestedRaggedTensorDict:
                 return self._get_slice_indices_internal(S, 0, {})
             case _:
                 raise TypeError(f"{type(idx)} not supported for {self.__class__.__name__} slicing")
+
+    def _check_int_index(self, i: int) -> int:
+        """Bounds-check and normalize a dim-0 integer index.
+
+        Out-of-range int indexing previously silently returned an empty JNRT (positive
+        index) or raised a cryptic internal ``IndexError`` (negative index, see #52);
+        this method replaces both with a clean ``IndexError`` matching Python/numpy
+        list semantics. Only dim-0 is covered here — deeper-dim int bounds depend on
+        per-row lengths in a ragged tensor and are out of scope for this check.
+
+        Examples:
+            >>> J = JointNestedRaggedTensorDict({"T": [1, 2, 3]})
+            >>> J._check_int_index(0)
+            0
+            >>> J._check_int_index(2)
+            2
+            >>> J._check_int_index(-1)
+            2
+            >>> J._check_int_index(-3)
+            0
+            >>> J._check_int_index(3)
+            Traceback (most recent call last):
+                ...
+            IndexError: Index 3 is out of range for JointNestedRaggedTensorDict of length 3.
+            >>> J._check_int_index(-4)
+            Traceback (most recent call last):
+                ...
+            IndexError: Index -4 is out of range for JointNestedRaggedTensorDict of length 3.
+        """
+        n = len(self)
+        if not -n <= i < n:
+            raise IndexError(f"Index {i} is out of range for {self.__class__.__name__} of length {n}.")
+        return i if i >= 0 else i + n
 
     def _get_slice_indices_internal(
         self, idx: slice, starting_dim: int, curr_indices: dict[str, slice]


### PR DESCRIPTION
## Summary

Closes #52.

Out-of-range int indexing was inconsistent and unhelpful across every dim:

| Access | Before | After |
|---|---|---|
| `J[5]` (len 3) | silent empty JNRT | **IndexError** at dim 0 |
| `J[-10]` (len 3) | cryptic `"index -11 is out of bounds for axis 0 with size 3"` | **IndexError** at dim 0 |
| `J[0, 5]` (row 0 has 3 elems) | silent empty JNRT | **IndexError** at dim 1 |
| `J[1, 2]` (row 1 has 2 elems) | silent empty JNRT | **IndexError** at dim 1 |
| `J[0, 0, 5]` 3D (row (0,0) has 3 elems) | silent empty JNRT | **IndexError** at dim 2 |
| `J[np.array([0, 5])]` | internal error during stacking | **IndexError** at dim 0 |
| `J[1:10]` | `[2, 3]` (numpy-like clip) | unchanged |
| `J[5:10]` | `[]` (numpy-like clip) | unchanged |

**Recursive at any depth** — not just dim 0. The check reuses the row-length state that `_get_slice_indices_internal` already walks via the bounds arrays:

- After the tuple loop processes a dim, the next dim's row length is derivable from `out_indices`: either from a data-key slice at that dim (start/stop give the flat span = row length), or — when a dim has no data keys — from the bounds slice + bounds tensor. Exposed as `_row_length_from_out_indices(out, dim)`.
- `current_length` starts at `len(self)` for dim 0 and rolls forward to the currently-selected row's length at each deeper dim.

Same `IndexError` message at every depth:

> `Index X is out of range at dim D (length N).`

## Test plan

- [x] Doctests cover: dim 0 (`J[5]`, `J[-4]`), dim 1 (`J[0, 3]`, `J[1, 2]`, `J[1, -5]`, valid `J[0, -1]`), dim 2 (`J[0, 0, 5]`, `J[1, 0, 2]`), ndarray-of-ints, slice clip-to-size behavior (preserved).
- [x] `_row_length_from_out_indices` doctest includes the no-data-key-at-dim fallback case.
- [x] 100% coverage maintained.
- [ ] CI green on the updated commit.

## Breaking change

Any caller relying on `J[too_big] -> empty JNRT` now gets `IndexError`. Silent empties cascade into hard-to-debug downstream issues, so this is a correctness fix rather than a behavior-preservation regression. Release-note callout.
