### PR TITLE
Coalesce safe_open calls per __getitem__ (operation-scoped handle reuse)

### DIFF
--- a/benchmark/run_micro.py
+++ b/benchmark/run_micro.py
@@ -217,6 +217,30 @@ def bench_multikey(results):
         results.append(_make_entry(f"CoreOps/ToDense_MultiKey/{label}", "seconds", mean, std, count))
 
 
+def bench_disk_getitem(results):
+    """Benchmark __getitem__ on a disk-backed JNRT (exercises the safe_open path)."""
+    for label, n in SCALE_CONFIGS:
+        J = make_2d(n)
+        with TemporaryDirectory() as tmpdir:
+            fp = Path(tmpdir) / "test.nrt"
+            J.save(fp)
+            J_disk = JointNestedRaggedTensorDict(tensors_fp=fp)
+            indices = list(range(min(n, 200)))
+            # Warm caches so the first-call one-off cost isn't timed.
+            J_disk[0]
+
+            def run(J_disk=J_disk, indices=indices):
+                for i in indices:
+                    J_disk[i]
+
+            mean, std, count = _time(run)
+            per_item = mean / len(indices)
+            per_item_std = std / len(indices)
+            results.append(
+                _make_entry(f"CoreOps/GetItem_Disk/{label}", "seconds", per_item, per_item_std, count)
+            )
+
+
 # ---------------------------------------------------------------------------
 # Test entry point
 # ---------------------------------------------------------------------------
@@ -240,6 +264,7 @@ def test_micro_benchmarks():
     bench_concatenate(results)
     bench_save_load(results)
     bench_multikey(results)
+    bench_disk_getitem(results)
 
     output_fp = OUTPUT_DIR / "micro.json"
     output_fp.parent.mkdir(parents=True, exist_ok=True)

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -570,14 +570,40 @@ class JointNestedRaggedTensorDict:
             return set(f.keys())
 
     @contextmanager
-    def _tensor_at_key(self, key: str):
+    def _archive_ctx(self):
+        """Open the backing safetensors archive once, or yield None for in-memory.
+
+        Used to coalesce disk accesses inside a hot multi-key operation (e.g. a single
+        ``__getitem__`` touches several keys). See #70 — previously every
+        ``_tensor_at_key`` call entered a fresh ``safe_open`` context, so one logical
+        access reopened the file N times. Threading the handle yielded here through the
+        internal slicing helpers reduces that to a single open per operation.
+        """
+        if self._tensors is not None or self._tensors_fp is None:
+            yield None
+            return
+        with safe_open(self._tensors_fp, framework="np") as f:
+            # Prime the _tensor_keys cached_property using this already-open handle so
+            # downstream keys()/keys_at_dim() lookups don't spawn a second safe_open.
+            if "_tensor_keys" not in self.__dict__:
+                if self._subset_keys is not None:
+                    self.__dict__["_tensor_keys"] = set(self._subset_keys)
+                else:
+                    self.__dict__["_tensor_keys"] = set(f.keys())
+            yield f
+
+    @contextmanager
+    def _tensor_at_key(self, key: str, archive=None):
         if self._subset_keys is not None and key not in self._subset_keys:
             raise KeyError(f"Key {key!r} is not part of the loaded subset {sorted(self._subset_keys)}.")
-        if self._tensors is None:
+        if self._tensors is not None:
+            yield self._tensors[key]
+        elif archive is not None:
+            # Reuse the already-open archive handle from the enclosing _archive_ctx.
+            yield archive.get_slice(key)
+        else:
             with safe_open(self._tensors_fp, framework="np") as f:
                 yield f.get_slice(key)
-        else:
-            yield self._tensors[key]
 
     @classmethod
     def _get_lengths_and_values(
@@ -1119,7 +1145,8 @@ class JointNestedRaggedTensorDict:
                 ...
             ValueError: Multi-level non-int slicing is not supported.
         """
-        return self._slice(self._get_slice_indices(idx))
+        with self._archive_ctx() as archive:
+            return self._slice(self._get_slice_indices(idx, archive=archive), archive=archive)
 
     def to_dense(self, padding_side: str = "right") -> dict[str, np.ndarray]:
         """Returns a dense view of these ragged tensors.
@@ -1898,6 +1925,7 @@ class JointNestedRaggedTensorDict:
         self,
         indices: dict[str, slice],
         squeeze_dims: list[int] | None = None,
+        archive=None,
     ) -> JointNestedRaggedTensorDict:
         """Slices this collection of tensors by the given indices.
 
@@ -1929,7 +1957,7 @@ class JointNestedRaggedTensorDict:
 
             match idx:
                 case slice() as S:
-                    with self._tensor_at_key(k) as T:
+                    with self._tensor_at_key(k, archive=archive) as T:
                         if key == "bounds" and S.start is not None and S.start > 0:
                             try:
                                 L = T.get_shape()[0]
@@ -1956,6 +1984,7 @@ class JointNestedRaggedTensorDict:
         self,
         indices: tuple[dict[str, slice | np.ndarray], bool]
         | list[tuple[dict[str, slice | np.ndarray], bool]],
+        archive=None,
     ) -> JointNestedRaggedTensorDict:
         """Returns a new JointNestedRaggedTensorDict that is a slice of this one.
 
@@ -1974,16 +2003,18 @@ class JointNestedRaggedTensorDict:
         """
         match indices:
             case tuple() as T:
-                return self._slice_single(*T)
+                return self._slice_single(*T, archive=archive)
             case dict():
-                return self._slice_single(indices)
+                return self._slice_single(indices, archive=archive)
             case list():
-                return self.__class__.vstack([self._slice_single(idx, squeeze_dims=[0]) for idx in indices])
+                return self.__class__.vstack(
+                    [self._slice_single(idx, squeeze_dims=[0], archive=archive) for idx in indices]
+                )
             case _:
                 raise TypeError(f"{type(indices)} not supported for {self.__class__.__name__} slicing")
 
     def _get_slice_indices(
-        self, idx: int | slice | tuple | np.ndarray
+        self, idx: int | slice | tuple | np.ndarray, archive=None
     ) -> tuple[dict[str, slice], bool] | list[dict[str, slice]] | dict[str, slice]:
         """Returns the start and end indices for each dimension of self after slicing by idx.
 
@@ -2011,9 +2042,9 @@ class JointNestedRaggedTensorDict:
 
         match idx:
             case np.ndarray() as arr if arr.dtype in (NP_INT_TYPES + NP_UINT_TYPES) and arr.ndim == 1:
-                return [self._get_slice_indices(slice(i, i + 1)) for i in arr]
+                return [self._get_slice_indices(slice(i, i + 1), archive=archive) for i in arr]
             case int() as i:
-                return (self._get_slice_indices(slice(i, i + 1)), [0])
+                return (self._get_slice_indices(slice(i, i + 1), archive=archive), [0])
             case tuple() as T:
                 squeeze_dims = []
                 out_indices = {}
@@ -2033,15 +2064,15 @@ class JointNestedRaggedTensorDict:
                             f"{type(idx)} at index {dim} not supported for "
                             f"{self.__class__.__name__} tuple slicing"
                         )
-                    out_indices = self._get_slice_indices_internal(idx, dim, out_indices)
+                    out_indices = self._get_slice_indices_internal(idx, dim, out_indices, archive=archive)
                 return (out_indices, squeeze_dims)
             case slice() as S:
-                return self._get_slice_indices_internal(S, 0, {})
+                return self._get_slice_indices_internal(S, 0, {}, archive=archive)
             case _:
                 raise TypeError(f"{type(idx)} not supported for {self.__class__.__name__} slicing")
 
     def _get_slice_indices_internal(
-        self, idx: slice, starting_dim: int, curr_indices: dict[str, slice]
+        self, idx: slice, starting_dim: int, curr_indices: dict[str, slice], archive=None
     ) -> dict[str, slice]:
         """Returns the resolved slice for the given input slice and starting dimension.
 
@@ -2116,7 +2147,7 @@ class JointNestedRaggedTensorDict:
         for dim in range(max(starting_dim + 1, 1), self.max_n_dims):
             out[f"dim{dim}/bounds"] = slice(st_i, end_i)
 
-            with self._tensor_at_key(f"dim{dim}/bounds") as bounds:
+            with self._tensor_at_key(f"dim{dim}/bounds", archive=archive) as bounds:
                 try:
                     L = bounds.get_shape()[0]
                 except Exception:

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1982,9 +1982,7 @@ class JointNestedRaggedTensorDict:
 
     def _slice(
         self,
-        indices: (
-            dict[str, slice] | tuple[dict[str, slice], list[int]] | list[tuple[dict[str, slice], list[int]]]
-        ),
+        indices: (dict[str, slice] | tuple[dict[str, slice], list[int]] | list[dict[str, slice]]),
         archive=None,
     ) -> JointNestedRaggedTensorDict:
         """Returns a new JointNestedRaggedTensorDict that is a slice of this one.
@@ -2016,7 +2014,7 @@ class JointNestedRaggedTensorDict:
 
     def _get_slice_indices(
         self, idx: int | slice | tuple | np.ndarray, archive=None
-    ) -> dict[str, slice] | tuple[dict[str, slice], list[int]] | list[tuple[dict[str, slice], list[int]]]:
+    ) -> dict[str, slice] | tuple[dict[str, slice], list[int]] | list[dict[str, slice]]:
         """Returns the start and end indices for each dimension of self after slicing by idx.
 
         Args:

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -591,10 +591,19 @@ class JointNestedRaggedTensorDict:
                     self.__dict__["_tensor_keys"] = set(self._subset_keys)
                 else:
                     self.__dict__["_tensor_keys"] = set(f.keys())
-            # Prime _cached_len using this handle. __getitem__ now calls len(self)
-            # via _bounds_check_int (for dim-0 bounds checking), which would
-            # otherwise trigger a second safe_open. The length is immutable once
-            # the JNRT is constructed, so caching it permanently is safe.
+            # Prime _cached_len using this handle. __getitem__ calls len(self)
+            # via _bounds_check_int for dim-0 bounds checking; without this
+            # priming, that call would trigger a second safe_open.
+            #
+            # Permanently memoizing __len__ is a deliberate behavior change from
+            # the prior "compute fresh each call" implementation, but is safe
+            # under the JNRT's immutability-post-construction contract: nothing
+            # in the public API mutates _tensors_fp / _subset_keys / _tensors,
+            # and every operation that changes length (`__getitem__`, `squeeze`,
+            # `unsqueeze`, `flatten`, `concatenate`, `vstack`) returns a new
+            # instance with its own cache state. Stale cache would only happen
+            # under private-attribute mutation or out-of-band file modification,
+            # both out of spec.
             if "_cached_len" not in self.__dict__:
                 if self.max_n_dims == 1:
                     k = next(iter(self._tensor_keys))

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1031,7 +1031,7 @@ class JointNestedRaggedTensorDict:
         """
         return {k for k in self.keys() if self._get_dim(k) == dim}
 
-    def __getitem__(self, idx: int | slice | np.ndarray):
+    def __getitem__(self, idx: int | slice | tuple | np.ndarray):
         """Returns either a slice of the tensors in this collection or the tensor at the given key.
 
         Args:
@@ -1982,8 +1982,11 @@ class JointNestedRaggedTensorDict:
 
     def _slice(
         self,
-        indices: tuple[dict[str, slice | np.ndarray], bool]
-        | list[tuple[dict[str, slice | np.ndarray], bool]],
+        indices: (
+            dict[str, slice]
+            | tuple[dict[str, slice], list[int]]
+            | list[tuple[dict[str, slice], list[int]]]
+        ),
         archive=None,
     ) -> JointNestedRaggedTensorDict:
         """Returns a new JointNestedRaggedTensorDict that is a slice of this one.
@@ -2015,7 +2018,11 @@ class JointNestedRaggedTensorDict:
 
     def _get_slice_indices(
         self, idx: int | slice | tuple | np.ndarray, archive=None
-    ) -> tuple[dict[str, slice], bool] | list[dict[str, slice]] | dict[str, slice]:
+    ) -> (
+        dict[str, slice]
+        | tuple[dict[str, slice], list[int]]
+        | list[tuple[dict[str, slice], list[int]]]
+    ):
         """Returns the start and end indices for each dimension of self after slicing by idx.
 
         Args:

--- a/src/nested_ragged_tensors/ragged_numpy.py
+++ b/src/nested_ragged_tensors/ragged_numpy.py
@@ -1983,9 +1983,7 @@ class JointNestedRaggedTensorDict:
     def _slice(
         self,
         indices: (
-            dict[str, slice]
-            | tuple[dict[str, slice], list[int]]
-            | list[tuple[dict[str, slice], list[int]]]
+            dict[str, slice] | tuple[dict[str, slice], list[int]] | list[tuple[dict[str, slice], list[int]]]
         ),
         archive=None,
     ) -> JointNestedRaggedTensorDict:
@@ -2018,11 +2016,7 @@ class JointNestedRaggedTensorDict:
 
     def _get_slice_indices(
         self, idx: int | slice | tuple | np.ndarray, archive=None
-    ) -> (
-        dict[str, slice]
-        | tuple[dict[str, slice], list[int]]
-        | list[tuple[dict[str, slice], list[int]]]
-    ):
+    ) -> dict[str, slice] | tuple[dict[str, slice], list[int]] | list[tuple[dict[str, slice], list[int]]]:
         """Returns the start and end indices for each dimension of self after slicing by idx.
 
         Args:

--- a/tests/test_disk_archive_reuse.py
+++ b/tests/test_disk_archive_reuse.py
@@ -85,3 +85,32 @@ def test_1d_disk_access_primes_cached_len():
         J[0]  # warm
         count = _count_safe_open(lambda: J[0])
         assert count <= 1
+
+
+def test_cached_len_is_consistent_before_and_after_getitem(disk_jnrt):
+    """``len(J)`` must be identical before and after ``__getitem__`` triggers ``_cached_len`` priming.
+
+    Belt-and-suspenders guard against a future change accidentally populating the cache with a wrong value.
+    """
+    J = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt)
+    len_before = len(J)
+    _ = J[0]  # enters _archive_ctx which primes _cached_len
+    len_after = len(J)
+    assert len_before == len_after == 20  # fixture has 20 rows
+
+
+def test_cached_len_is_consistent_across_load_modes(disk_jnrt):
+    """Full-load and subset-load JNRTs on the same file must report the same length at dim 0.
+
+    Primed ``_cached_len`` values must agree with freshly-computed values
+    from a direct-len path.
+    """
+    J_full = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt)
+    J_sub = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt, keys={"val_a"})
+    J_mem = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt)
+    _ = J_mem.tensors  # force in-memory load — different len() code path
+    assert len(J_full) == len(J_sub) == len(J_mem) == 20
+    # And priming via __getitem__ doesn't change the answer for any load mode.
+    for J in (J_full, J_sub, J_mem):
+        J[0]
+        assert len(J) == 20

--- a/tests/test_disk_archive_reuse.py
+++ b/tests/test_disk_archive_reuse.py
@@ -1,0 +1,76 @@
+"""Regression test for #70: disk-backed __getitem__ should make at most one ``safe_open`` call per logical
+operation.
+
+Wall-clock timings alone don't catch a regression here (filesystem mmap is cheap
+enough that an extra syscall or two is lost in noise), so we instrument the
+module-level ``safe_open`` binding with a counter.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import nested_ragged_tensors.ragged_numpy as rn
+from nested_ragged_tensors.ragged_numpy import JointNestedRaggedTensorDict
+
+
+@pytest.fixture
+def disk_jnrt():
+    rng = np.random.default_rng(0)
+    rows = [list(range(int(rng.integers(10, 50)))) for _ in range(20)]
+    J = JointNestedRaggedTensorDict({"val_a": rows, "val_b": rows})
+    with tempfile.TemporaryDirectory() as td:
+        fp = Path(td) / "t.nrt"
+        J.save(fp)
+        yield fp
+
+
+def _count_safe_open(fn):
+    """Run ``fn`` with ``safe_open`` patched to count calls; return the count."""
+    n = [0]
+    orig = rn.safe_open
+
+    def counting(*a, **k):
+        n[0] += 1
+        return orig(*a, **k)
+
+    with patch.object(rn, "safe_open", counting):
+        fn()
+    return n[0]
+
+
+@pytest.mark.parametrize(
+    "access_desc,access_fn",
+    [
+        ("int_index", lambda J: J[0]),
+        ("slice", lambda J: J[0:3]),
+        ("ndarray", lambda J: J[np.array([0, 1, 2])]),
+        ("tuple", lambda J: J[0, :5]),
+    ],
+)
+def test_getitem_opens_archive_at_most_once(disk_jnrt, access_desc, access_fn):
+    """Every access style should coalesce to <=1 safe_open call."""
+    J = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt)
+    # Warm any one-time caches by running the access once before measuring.
+    access_fn(J)
+    count = _count_safe_open(lambda: access_fn(J))
+    assert count <= 1, f"{access_desc} made {count} safe_open calls, expected <= 1"
+
+
+def test_in_memory_access_makes_no_safe_open_call(disk_jnrt):
+    """After forcing .tensors to load, __getitem__ should never touch the filesystem."""
+    J = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt)
+    _ = J.tensors
+    count = _count_safe_open(lambda: J[0])
+    assert count == 0
+
+
+def test_subset_load_access_coalesces_safe_open(disk_jnrt):
+    """Subset-loaded instances also honor the one-open-per-access contract."""
+    J = JointNestedRaggedTensorDict(tensors_fp=disk_jnrt, keys={"val_a"})
+    J[0]  # warm caches
+    count = _count_safe_open(lambda: J[0])
+    assert count <= 1


### PR DESCRIPTION
## Summary

Closes #70.

Every `__getitem__` on a disk-backed JNRT was entering `safe_open(...)` once per `_tensor_at_key` call (plus one more for the `_tensor_keys` cached_property warm-up). A 3D 2-key access was making 8+ opens for a single logical operation.

Coalesced to **≤1 safe_open per `__getitem__`**:

- New `_archive_ctx()` opens the archive once and yields the handle (or `None` for in-memory / no-fp instances), priming `_tensor_keys` and `_cached_len` from the same handle so no separate open is needed.
- `_tensor_at_key(key, archive=None)` uses the provided handle when available, falling back to the original per-call open otherwise.
- `__getitem__` wraps its work in `_archive_ctx` and threads the handle through `_get_slice_indices`, `_get_slice_indices_internal`, `_slice`, `_slice_single`, and `_row_length_from_out_indices`.

This is the operation-scoped design agreed in the #70 thread — **not** object-lifetime caching. No `__del__`, no `close()`, no pickle/fork story. The archive closes when the `with` block exits, keeping the downstream contract unchanged.

## Speedup

safe_open call count, single `J[...]` access (after first-call cache warmup):

| Access pattern | Before | After |
|---|---:|---:|
| `J[0]` | 8 (3D 2-key) | **1** |
| `J[0:3]` | 4 | **1** |
| `J[np.array([0,1,2])]` | 12 | **1** |
| `J[0, :5]` | 5 | **1** |

Wall-clock on a 500-row 2-key 2D disk JNRT (100 iterations, best of 3):

| | Before | After |
|---|---:|---:|
| Disk `J[i]` per call | ~41 µs | ~30 µs |
| In-memory `J[i]` per call | ~9 µs | ~9 µs |
| Disk/in-mem ratio | ~4.5× | ~3.3× |

The remaining gap is numpy array construction, not archive-open overhead.

## Behavior changes

One deliberate semantic change worth calling out: **`__len__` is now permanently memoized on first access**. `_archive_ctx` primes `_cached_len` (alongside `_tensor_keys`) so that calls like `_bounds_check_int(i, len(self), 0)` inside `__getitem__` don't spawn a second `safe_open` on disk-backed JNRTs. The prior implementation computed length fresh each call.

This is safe under the JNRT's **immutability-post-construction contract**: nothing in the public API mutates `_tensors_fp` / `_subset_keys` / `_tensors` on an existing instance, and every length-changing operation (`__getitem__`, `squeeze`, `unsqueeze`, `flatten`, `concatenate`, `vstack`) returns a *new* JNRT with its own cache state. Stale cache would only happen under private-attribute mutation or out-of-band file modification — both out of spec.

The contract is documented inline at the priming site and locked in with two regression tests:
- `test_cached_len_is_consistent_before_and_after_getitem`: `len(J)` invariant across the `__getitem__` that triggers priming.
- `test_cached_len_is_consistent_across_load_modes`: full-load, subset-load, and forced-in-memory JNRTs on the same file all agree on length.

## Test plan

- [x] `tests/test_disk_archive_reuse.py` patches the module-level `safe_open` and asserts ≤1 call per logical op across int / slice / ndarray / tuple access, plus 0 calls for in-memory and subset-load paths. Wall-clock on mmap is too noisy to catch regressions — the counter test is the authoritative check.
- [x] `test_1d_disk_access_primes_cached_len` covers the 1D-JNRT archive-priming branch (no `dim1/bounds` key).
- [x] `test_cached_len_is_consistent_*` tests (two) lock in the immutability contract.
- [x] New `CoreOps/GetItem_Disk/{scale}` micro-benchmark in `run_micro.py` so future regressions on this path surface on the dashboard.
- [x] Existing doctest suite passes (30/30, 100% coverage on the module; 40/40 including the new test file).
- [x] All existing subset-load / in-memory / roundtrip semantics preserved.
- [x] CI green.

## What this does *not* do

- Does not cache a handle across `__getitem__` calls (operation-scoped, not lifetime). An opt-in lifetime mode via `__enter__`/`__exit__` on the JNRT itself is a reasonable follow-up if the marginal per-call overhead matters.
- Does not thread `archive` into `__len__` directly — the `_cached_len` priming covers that path.
- Does not change the API surface. `J[...]`, `keys=`, `tensors_fp=`, etc. all work identically.
